### PR TITLE
Add minio client to fetch results of child submission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,5 +207,5 @@ marimo/_lsp/
 __marimo__/
 .DS_Store
 
-
+.cursor/
 testconfig.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ authors = [
 ]
 requires-python = ">=3.13"
 dependencies = [
+    "minio>=7.2.20",
     "py-tes>=1.1.2",
     "pydantic>=2.13.1",
     "pyyaml>=6.0.3",

--- a/src/five_safes_tes_workbench/constants/minio.py
+++ b/src/five_safes_tes_workbench/constants/minio.py
@@ -1,0 +1,5 @@
+"""Constants for MinIO operations."""
+
+STS_NAMESPACE = {"sts": "https://sts.amazonaws.com/doc/2011-06-15/"}
+STS_DURATION_SECONDS = "3600"
+STS_TOKEN_EXCHANGE_TIMEOUT = 60

--- a/src/five_safes_tes_workbench/constants/task_status.py
+++ b/src/five_safes_tes_workbench/constants/task_status.py
@@ -1,0 +1,164 @@
+from enum import IntEnum
+
+
+class TaskStatus(IntEnum):
+    """
+    Enum for task status codes with their corresponding display names.
+    source: https://github.com/SwanseaUniversityMedical/5s-Tes/blob/main/Shared/FiveSafesTes.Core/Models/Enums/Enums.cs
+    """
+
+    # Parent only
+    WAITING_FOR_CHILD_SUBS_TO_COMPLETE = 0
+    # Stage 1
+    WAITING_FOR_AGENT_TO_TRANSFER = 1
+    # Stage 2
+    TRANSFERRED_TO_POD = 2
+    # Stage 3
+    POD_PROCESSING = 3
+    # Stage 3 - Green
+    POD_PROCESSING_COMPLETE = 4
+    # Stage 4
+    DATA_OUT_APPROVAL_BEGUN = 5
+    # Stage 4 - Red
+    DATA_OUT_APPROVAL_REJECTED = 6
+    # Stage 4 - Green
+    DATA_OUT_APPROVED = 7
+    # Stage 1 - Red
+    USER_NOT_ON_PROJECT = 8
+    # Stage 2 - Red
+    INVALID_USER = 9
+    # Stage 2 - Red
+    TRE_NOT_AUTHORISED_FOR_PROJECT = 10
+    # Stage 5 - Green (completed enum)
+    COMPLETED = 11
+    # Stage 1 - Red
+    INVALID_SUBMISSION = 12
+    # Stage 1 - Red
+    CANCELLING_CHILDREN = 13
+    # Stage 1 - Red
+    REQUEST_CANCELLATION = 14
+    # Stage 1 - Red
+    CANCELLATION_REQUEST_SENT = 15
+    # Stage 5 - Red
+    CANCELLED = 16
+    # Stage 1
+    SUBMISSION_WAITING_FOR_CRATE_FORMAT_CHECK = 17
+    # Unused
+    VALIDATING_USER = 18
+    # Unused
+    VALIDATING_SUBMISSION = 19
+    # Unused - Green
+    VALIDATION_SUCCESSFUL = 20
+    # Stage 2
+    AGENT_TRANSFERRING_TO_POD = 21
+    # Stage 2 - Red
+    TRANSFER_TO_POD_FAILED = 22
+    # Unused
+    TRE_REJECTED_PROJECT = 23
+    # Unused
+    TRE_APPROVED_PROJECT = 24
+    # Stage 3 - Red
+    POD_PROCESSING_FAILED = 25
+    # Stage 1 - Parent only
+    RUNNING = 26
+    # Stage 5 - Red
+    FAILED = 27
+    # Stage 2
+    SENDING_SUBMISSION_TO_HUTCH = 28
+    # Stage 4
+    REQUESTING_HUTCH_DOES_FINAL_PACKAGING = 29
+    # Stage 3
+    WAITING_FOR_CRATE = 30
+    # Stage 3
+    FETCHING_CRATE = 31
+    # Stage 3
+    QUEUED = 32
+    # Stage 3
+    VALIDATING_CRATE = 33
+    # Stage 3
+    FETCHING_WORKFLOW = 34
+    # Stage 3
+    STAGING_WORKFLOW = 35
+    # Stage 3
+    EXECUTING_WORKFLOW = 36
+    # Stage 3
+    PREPARING_OUTPUTS = 37
+    # Stage 3
+    DATA_OUT_REQUESTED = 38
+    # Stage 3
+    TRANSFERRED_FOR_DATA_OUT = 39
+    # Stage 3
+    PACKAGING_APPROVED_RESULTS = 40
+    # Stage 3 - Green
+    COMPLETE = 41
+    # Stage 3 - Red
+    FAILURE = 42
+    # Stage 1
+    SUBMISSION_RECEIVED = 43
+    # Stage 1 - Green
+    SUBMISSION_CRATE_VALIDATED = 44
+    # Stage 1 - Red
+    SUBMISSION_CRATE_VALIDATION_FAILED = 45
+    # Stage 2 - Green
+    TRE_CRATE_VALIDATED = 46
+    # Stage 2 - Red
+    TRE_CRATE_VALIDATION_FAILED = 47
+    # Stage 2
+    TRE_WAITING_FOR_CRATE_FORMAT_CHECK = 48
+    # Stage 5 - Green - Parent Only
+    PARTIAL_RESULT = 49
+
+
+# Status lookup dictionary for easy access to display names
+TASK_STATUS_DESCRIPTIONS = {
+    TaskStatus.WAITING_FOR_CHILD_SUBS_TO_COMPLETE: "Waiting for Child Submissions To Complete",
+    TaskStatus.WAITING_FOR_AGENT_TO_TRANSFER: "Waiting for Agent To Transfer",
+    TaskStatus.TRANSFERRED_TO_POD: "Transferred To Pod",
+    TaskStatus.POD_PROCESSING: "Pod Processing",
+    TaskStatus.POD_PROCESSING_COMPLETE: "Pod Processing Complete",
+    TaskStatus.DATA_OUT_APPROVAL_BEGUN: "Data Out Approval Begun",
+    TaskStatus.DATA_OUT_APPROVAL_REJECTED: "Data Out Rejected",
+    TaskStatus.DATA_OUT_APPROVED: "Data Out Approved",
+    TaskStatus.USER_NOT_ON_PROJECT: "User Not On Project",
+    TaskStatus.INVALID_USER: "User not authorised for project on TRE",
+    TaskStatus.TRE_NOT_AUTHORISED_FOR_PROJECT: "TRE Not Authorised For Project",
+    TaskStatus.COMPLETED: "Completed",
+    TaskStatus.INVALID_SUBMISSION: "Invalid Submission",
+    TaskStatus.CANCELLING_CHILDREN: "Cancelling Children",
+    TaskStatus.REQUEST_CANCELLATION: "Request Cancellation",
+    TaskStatus.CANCELLATION_REQUEST_SENT: "Cancellation Request Sent",
+    TaskStatus.CANCELLED: "Cancelled",
+    TaskStatus.SUBMISSION_WAITING_FOR_CRATE_FORMAT_CHECK: "Waiting For Crate Format Check",
+    TaskStatus.VALIDATING_USER: "Validating User",
+    TaskStatus.VALIDATING_SUBMISSION: "Validating Submission",
+    TaskStatus.VALIDATION_SUCCESSFUL: "Validation Successful",
+    TaskStatus.AGENT_TRANSFERRING_TO_POD: "Agent Transferring To Pod",
+    TaskStatus.TRANSFER_TO_POD_FAILED: "Transfer To Pod Failed",
+    TaskStatus.TRE_REJECTED_PROJECT: "Tre Rejected Project",
+    TaskStatus.TRE_APPROVED_PROJECT: "Tre Approved Project",
+    TaskStatus.POD_PROCESSING_FAILED: "Pod Processing Failed",
+    TaskStatus.RUNNING: "Running",
+    TaskStatus.FAILED: "Failed",
+    TaskStatus.SENDING_SUBMISSION_TO_HUTCH: "Sending submission to Hutch",
+    TaskStatus.REQUESTING_HUTCH_DOES_FINAL_PACKAGING: "Requesting Hutch packages up final output",
+    TaskStatus.WAITING_FOR_CRATE: "Waiting for a Crate",
+    TaskStatus.FETCHING_CRATE: "Fetching Crate",
+    TaskStatus.QUEUED: "Crate queued",
+    TaskStatus.VALIDATING_CRATE: "Validating Crate",
+    TaskStatus.FETCHING_WORKFLOW: "Fetching workflow",
+    TaskStatus.STAGING_WORKFLOW: "Preparing workflow",
+    TaskStatus.EXECUTING_WORKFLOW: "Executing workflow",
+    TaskStatus.PREPARING_OUTPUTS: "Preparing outputs",
+    TaskStatus.DATA_OUT_REQUESTED: "Requested Egress",
+    TaskStatus.TRANSFERRED_FOR_DATA_OUT: "Waiting for Egress results",
+    TaskStatus.PACKAGING_APPROVED_RESULTS: "Finalising approved results",
+    TaskStatus.COMPLETE: "Completed",
+    TaskStatus.FAILURE: "Failed",
+    TaskStatus.SUBMISSION_RECEIVED: "Submission has been received",
+    TaskStatus.SUBMISSION_CRATE_VALIDATED: "Crate Validated",
+    TaskStatus.SUBMISSION_CRATE_VALIDATION_FAILED: "Crate Failed Validation",
+    TaskStatus.TRE_CRATE_VALIDATED: "Crate Validated",
+    TaskStatus.TRE_CRATE_VALIDATION_FAILED: "Crate Failed Validation",
+    TaskStatus.TRE_WAITING_FOR_CRATE_FORMAT_CHECK: "Waiting For Crate Format Check",
+    TaskStatus.PARTIAL_RESULT: "Complete but not all TREs returned a result",
+}

--- a/src/five_safes_tes_workbench/core/minio_builder.py
+++ b/src/five_safes_tes_workbench/core/minio_builder.py
@@ -69,7 +69,11 @@ class WorkbenchMinioBuilder:
         )
         self._config = config
 
-        logger.info("MinIO client initialised (endpoint=%s, secure=%s)", config.minio_endpoint, secure)
+        logger.info(
+            "MinIO client initialised (endpoint=%s, secure=%s)",
+            config.minio_endpoint,
+            secure,
+        )
 
     # ------------------------------------------------------------------
     # Public result-fetching methods
@@ -97,7 +101,9 @@ class WorkbenchMinioBuilder:
         prefix = f"{task_id}/"
 
         try:
-            objects = client.list_objects(resolved_bucket, prefix=prefix, recursive=True)
+            objects = client.list_objects(
+                resolved_bucket, prefix=prefix, recursive=True
+            )
             names = [obj.object_name for obj in objects]
             logger.info("Found %d result object(s) for task %s", len(names), task_id)
             return names
@@ -135,7 +141,7 @@ class WorkbenchMinioBuilder:
                 return None
             raise
 
-    def get_result_parsed(
+    def _parse_result(
         self, object_path: str, bucket: str | None = None
     ) -> str | dict[str, Any] | list[Any] | None:
         """
@@ -168,6 +174,27 @@ class WorkbenchMinioBuilder:
 
         return content
 
+    def get_child_task_id(self, parent_task_id: str, tre: str) -> str:
+        """
+        Get the child task ID for a given task and TRE.
+        """
+        response = requests.get(
+            f"{self._config.tes_base_url.rstrip('/')}/api/Submission/GetChildSubmissionIdByParentAndTre?parentSubmissionId={parent_task_id}&treName={tre}"
+        )
+        response.raise_for_status()
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Failed to get child task ID: {response.status_code} {response.text}"
+            )
+
+        child_task_id = response.json()
+        if child_task_id is None:
+            raise RuntimeError(
+                f"No child task ID found for parent task {parent_task_id} and TRE {tre}"
+            )
+        logger.info("Child task ID: %s", child_task_id)
+        return child_task_id
+
     def fetch_all_results(
         self, task_id: str, bucket: str | None = None
     ) -> dict[str, str | dict[str, Any] | list[Any] | None]:
@@ -192,7 +219,7 @@ class WorkbenchMinioBuilder:
         results: dict[str, str | dict[str, Any] | list[Any] | None] = {}
         for path in object_paths:
             logger.info("Fetching result object: %s", path)
-            results[path] = self.get_result_parsed(path, bucket=bucket)
+            results[path] = self._parse_result(path, bucket=bucket)
 
         return results
 
@@ -222,7 +249,9 @@ class WorkbenchMinioBuilder:
         Call the STS AssumeRoleWithWebIdentity action and return temporary
         AWS-style credentials.
         """
-        logger.info("Exchanging bearer token for MinIO credentials via STS (%s)", sts_endpoint)
+        logger.info(
+            "Exchanging bearer token for MinIO credentials via STS (%s)", sts_endpoint
+        )
 
         response = requests.post(
             sts_endpoint,
@@ -248,15 +277,23 @@ class WorkbenchMinioBuilder:
             raise RuntimeError("STS response contained no Credentials element")
 
         return {
-            "access_key": credentials.findtext("sts:AccessKeyId", namespaces=_STS_NS) or "",
-            "secret_key": credentials.findtext("sts:SecretAccessKey", namespaces=_STS_NS) or "",
-            "session_token": credentials.findtext("sts:SessionToken", namespaces=_STS_NS) or "",
+            "access_key": credentials.findtext("sts:AccessKeyId", namespaces=_STS_NS)
+            or "",
+            "secret_key": credentials.findtext(
+                "sts:SecretAccessKey", namespaces=_STS_NS
+            )
+            or "",
+            "session_token": credentials.findtext(
+                "sts:SessionToken", namespaces=_STS_NS
+            )
+            or "",
         }
 
 
 # ------------------------------------------------------------------
 # Module-level helper
 # ------------------------------------------------------------------
+
 
 def _is_https(url: str) -> bool:
     parsed = urlparse(url)

--- a/src/five_safes_tes_workbench/core/minio_builder.py
+++ b/src/five_safes_tes_workbench/core/minio_builder.py
@@ -195,7 +195,7 @@ class WorkbenchMinioBuilder:
         logger.info("Child task ID: %s", child_task_id)
         return child_task_id
 
-    def fetch_all_results(
+    def fetch_result(
         self, task_id: str, bucket: str | None = None
     ) -> dict[str, str | dict[str, Any] | list[Any] | None]:
         """

--- a/src/five_safes_tes_workbench/core/minio_builder.py
+++ b/src/five_safes_tes_workbench/core/minio_builder.py
@@ -1,0 +1,267 @@
+"""Builder responsible for fetching task results from MinIO after submission."""
+
+import json
+import csv
+import xml.etree.ElementTree as ET
+from io import StringIO
+from typing import Any
+from urllib.parse import urlparse
+
+import requests
+from minio import Minio
+import minio
+
+from ..schema.config_schema import ConfigValidationModel
+from ..schema.auth_schema import AuthValidationModel
+from ..core.submit_builder import WorkbenchSubmitBuilder
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+_STS_NS = {"sts": "https://sts.amazonaws.com/doc/2011-06-15/"}
+_STS_DURATION_SECONDS = "3600"
+
+
+class WorkbenchMinioBuilder:
+    """
+    Builder responsible for connecting to MinIO and retrieving task
+    output objects after a TES task has completed.
+
+    Credentials are obtained by exchanging the bearer token at the
+    configured STS endpoint (AssumeRoleWithWebIdentity).
+    """
+
+    def __init__(self) -> None:
+        self._client: Minio | None = None
+        self._config: ConfigValidationModel | None = None
+
+    # ------------------------------------------------------------------
+    # Initialisation
+    # ------------------------------------------------------------------
+
+    def initialise(
+        self,
+        config: ConfigValidationModel,
+        auth: AuthValidationModel,
+    ) -> None:
+        """
+        Exchange the bearer token for temporary MinIO credentials via STS
+        and create an authenticated Minio client.
+
+        Parameters
+        ----------
+        - config: Validated infrastructure configuration (STS endpoint,
+          MinIO endpoint, output bucket).
+        - auth: Validated authentication details used to obtain the bearer
+          token.
+        """
+        bearer = WorkbenchSubmitBuilder._resolve_bearer(auth)
+        credentials = self._exchange_token(bearer, config.minio_sts_endpoint)
+
+        secure = _is_https(config.minio_sts_endpoint)
+
+        self._client = Minio(
+            config.minio_endpoint,
+            access_key=credentials["access_key"],
+            secret_key=credentials["secret_key"],
+            session_token=credentials["session_token"],
+            secure=secure,
+        )
+        self._config = config
+
+        logger.info("MinIO client initialised (endpoint=%s, secure=%s)", config.minio_endpoint, secure)
+
+    # ------------------------------------------------------------------
+    # Public result-fetching methods
+    # ------------------------------------------------------------------
+
+    def list_results(self, task_id: str, bucket: str | None = None) -> list[str]:
+        """
+        List all output objects written by a task.
+
+        Objects are expected to live under the ``{task_id}/`` prefix in the
+        configured output bucket.
+
+        Parameters
+        ----------
+        - task_id: ID returned by the TES submission.
+        - bucket: Override the bucket from config. Defaults to
+          ``config.minio_output_bucket``.
+
+        Returns
+        -------
+        List of object names found under the task prefix.
+        """
+        client = self._require_client()
+        resolved_bucket = bucket or self._require_config().minio_output_bucket
+        prefix = f"{task_id}/"
+
+        try:
+            objects = client.list_objects(resolved_bucket, prefix=prefix, recursive=True)
+            names = [obj.object_name for obj in objects]
+            logger.info("Found %d result object(s) for task %s", len(names), task_id)
+            return names
+        except Exception as e:
+            logger.error("Error listing results for task %s: %s", task_id, e)
+            raise
+
+    def get_result(self, object_path: str, bucket: str | None = None) -> str | None:
+        """
+        Fetch a single result object as a raw UTF-8 string.
+
+        Parameters
+        ----------
+        - object_path: Full object path within the bucket (e.g.
+          ``"<task_id>/stdout"``)
+        - bucket: Override the bucket from config.
+
+        Returns
+        -------
+        String content of the object, or ``None`` if the object does not
+        exist.
+        """
+        client = self._require_client()
+        resolved_bucket = bucket or self._require_config().minio_output_bucket
+
+        try:
+            response = client.get_object(resolved_bucket, object_path)
+            content = response.read().decode("utf-8")
+            response.close()
+            response.release_conn()
+            return content
+        except minio.error.S3Error as e:
+            if e.code == "NoSuchKey":
+                logger.warning("Object not found: %s", object_path)
+                return None
+            raise
+
+    def get_result_parsed(
+        self, object_path: str, bucket: str | None = None
+    ) -> str | dict[str, Any] | list[Any] | None:
+        """
+        Fetch a single result object and auto-detect its format.
+
+        Attempts JSON first, then CSV (returning the first row as a dict),
+        then falls back to a raw string.
+
+        Parameters
+        ----------
+        - object_path: Full object path within the bucket.
+        - bucket: Override the bucket from config.
+        """
+        content = self.get_result(object_path, bucket=bucket)
+        if content is None:
+            return None
+
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError:
+            pass
+
+        try:
+            reader = csv.DictReader(StringIO(content))
+            rows = list(reader)
+            if rows:
+                return rows
+        except Exception:
+            pass
+
+        return content
+
+    def fetch_all_results(
+        self, task_id: str, bucket: str | None = None
+    ) -> dict[str, str | dict[str, Any] | list[Any] | None]:
+        """
+        Fetch all output objects for a task and return them as a mapping
+        of ``object_path -> parsed_content``.
+
+        Uses :meth:`get_result_parsed` for each object so content is
+        automatically decoded from JSON / CSV where possible.
+
+        Parameters
+        ----------
+        - task_id: ID returned by the TES submission.
+        - bucket: Override the bucket from config.
+
+        Returns
+        -------
+        Dict mapping each object path to its parsed content.
+        """
+        object_paths = self.list_results(task_id, bucket=bucket)
+
+        results: dict[str, str | dict[str, Any] | list[Any] | None] = {}
+        for path in object_paths:
+            logger.info("Fetching result object: %s", path)
+            results[path] = self.get_result_parsed(path, bucket=bucket)
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _require_client(self) -> Minio:
+        if self._client is None:
+            raise ValueError(
+                "MinIO client is not initialised. "
+                "Please call fetch_results() after submit()."
+            )
+        return self._client
+
+    def _require_config(self) -> ConfigValidationModel:
+        if self._config is None:
+            raise ValueError(
+                "MinIO builder has no config. "
+                "Please call fetch_results() after submit()."
+            )
+        return self._config
+
+    @staticmethod
+    def _exchange_token(bearer: str, sts_endpoint: str) -> dict[str, str]:
+        """
+        Call the STS AssumeRoleWithWebIdentity action and return temporary
+        AWS-style credentials.
+        """
+        logger.info("Exchanging bearer token for MinIO credentials via STS (%s)", sts_endpoint)
+
+        response = requests.post(
+            sts_endpoint,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data={
+                "Action": "AssumeRoleWithWebIdentity",
+                "Version": "2011-06-15",
+                "DurationSeconds": _STS_DURATION_SECONDS,
+                "WebIdentityToken": bearer,
+            },
+            timeout=30,
+        )
+
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"STS token exchange failed ({response.status_code}): {response.text}"
+            )
+
+        root = ET.fromstring(response.text)
+        credentials = root.find(".//sts:Credentials", _STS_NS)
+
+        if credentials is None:
+            raise RuntimeError("STS response contained no Credentials element")
+
+        return {
+            "access_key": credentials.findtext("sts:AccessKeyId", namespaces=_STS_NS) or "",
+            "secret_key": credentials.findtext("sts:SecretAccessKey", namespaces=_STS_NS) or "",
+            "session_token": credentials.findtext("sts:SessionToken", namespaces=_STS_NS) or "",
+        }
+
+
+# ------------------------------------------------------------------
+# Module-level helper
+# ------------------------------------------------------------------
+
+def _is_https(url: str) -> bool:
+    parsed = urlparse(url)
+    if parsed.scheme == "https":
+        return True
+    if parsed.scheme == "http":
+        return False
+    raise ValueError(f"URL must start with http:// or https://, got: {url!r}")

--- a/src/five_safes_tes_workbench/core/minio_client.py
+++ b/src/five_safes_tes_workbench/core/minio_client.py
@@ -37,8 +37,8 @@ class MinioClientBuilder:
         """
         bearer = resolve_bearer(auth)
         credentials = exchange_minio_token(bearer, config.minio_sts_endpoint)
-
-        secure = is_https(config.minio_sts_endpoint)
+        # Check if the MinIO endpoint is HTTPS
+        secure = is_https(config.minio_endpoint)
         self._client = Minio(
             config.minio_endpoint,
             access_key=credentials.access_key,

--- a/src/five_safes_tes_workbench/core/minio_client.py
+++ b/src/five_safes_tes_workbench/core/minio_client.py
@@ -6,9 +6,9 @@ from minio import Minio
 import xml.etree.ElementTree as ET
 
 from ..helpers.minio import is_https, list_results, get_and_parse_result
+from ..helpers.auth import resolve_bearer
 from ..schema.config_schema import ConfigValidationModel
 from ..schema.auth_schema import AuthValidationModel
-from ..core.submit_builder import WorkbenchSubmitBuilder
 from ..utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -50,7 +50,7 @@ class MinioClientBuilder:
         - auth: Validated authentication details used to obtain the bearer
           token.
         """
-        bearer = WorkbenchSubmitBuilder._resolve_bearer(auth)
+        bearer = resolve_bearer(auth)
         credentials = self._exchange_token(bearer, config.minio_sts_endpoint)
 
         secure = is_https(config.minio_sts_endpoint)

--- a/src/five_safes_tes_workbench/core/minio_client.py
+++ b/src/five_safes_tes_workbench/core/minio_client.py
@@ -22,7 +22,7 @@ _STS_NS = {"sts": "https://sts.amazonaws.com/doc/2011-06-15/"}
 _STS_DURATION_SECONDS = "3600"
 
 
-class WorkbenchMinioBuilder:
+class WorkbenchMinioClient:
     """
     Builder responsible for connecting to MinIO and retrieving task
     output objects after a TES task has completed.

--- a/src/five_safes_tes_workbench/core/minio_client.py
+++ b/src/five_safes_tes_workbench/core/minio_client.py
@@ -17,7 +17,7 @@ _STS_NS = {"sts": "https://sts.amazonaws.com/doc/2011-06-15/"}
 _STS_DURATION_SECONDS = "3600"
 
 
-class WorkbenchMinioClient:
+class MinioClientBuilder:
     """
     Builder responsible for connecting to MinIO and retrieving task
     output objects after a TES task has completed.

--- a/src/five_safes_tes_workbench/core/minio_client.py
+++ b/src/five_safes_tes_workbench/core/minio_client.py
@@ -1,11 +1,9 @@
 """Builder responsible for fetching task results from MinIO after submission."""
 
 from pathlib import Path
-from typing import Any
 from minio import Minio
 from ..helpers.minio import (
     list_results,
-    get_and_parse_result,
     download_result,
     exchange_minio_token,
 )
@@ -59,36 +57,6 @@ class MinioClientBuilder:
             config.minio_endpoint,
             secure,
         )
-
-    def fetch_result(
-        self, task_id: str, bucket: str | None = None
-    ) -> dict[str, str | dict[str, Any] | list[Any] | None]:
-        """
-        Fetch all output objects for a task and return them as a mapping
-        of ``object_path -> parsed_content``.
-
-        Uses :meth:`get_result_parsed` for each object so content is
-        automatically decoded from JSON / CSV where possible.
-
-        Parameters
-        ----------
-        - task_id: ID returned by the TES submission.
-        - bucket: Override the bucket from config.
-
-        Returns
-        -------
-        Dict mapping each object path to its parsed content.
-        """
-        object_paths = list_results(self._client, self._config, task_id, bucket=bucket)
-
-        results: dict[str, str | dict[str, Any] | list[Any] | None] = {}
-        for path in object_paths:
-            logger.info("Fetching result object: %s", path)
-            results[path] = get_and_parse_result(
-                self._client, self._config, path, bucket=bucket
-            )
-
-        return results
 
     def download_results(
         self,

--- a/src/five_safes_tes_workbench/core/minio_client.py
+++ b/src/five_safes_tes_workbench/core/minio_client.py
@@ -5,11 +5,12 @@ import csv
 import xml.etree.ElementTree as ET
 from io import StringIO
 from typing import Any
-from urllib.parse import urlparse
 
 import requests
 from minio import Minio
 import minio
+
+from ..helpers.minio import is_https, require_client, require_config
 
 from ..schema.config_schema import ConfigValidationModel
 from ..schema.auth_schema import AuthValidationModel
@@ -58,7 +59,7 @@ class WorkbenchMinioClient:
         bearer = WorkbenchSubmitBuilder._resolve_bearer(auth)
         credentials = self._exchange_token(bearer, config.minio_sts_endpoint)
 
-        secure = _is_https(config.minio_sts_endpoint)
+        secure = is_https(config.minio_sts_endpoint)
 
         self._client = Minio(
             config.minio_endpoint,
@@ -96,8 +97,8 @@ class WorkbenchMinioClient:
         -------
         List of object names found under the task prefix.
         """
-        client = self._require_client()
-        resolved_bucket = bucket or self._require_config().minio_output_bucket
+        client = require_client(self._client)
+        resolved_bucket = bucket or require_config(self._config).minio_output_bucket
         prefix = f"{task_id}/"
 
         try:
@@ -126,8 +127,8 @@ class WorkbenchMinioClient:
         String content of the object, or ``None`` if the object does not
         exist.
         """
-        client = self._require_client()
-        resolved_bucket = bucket or self._require_config().minio_output_bucket
+        client = require_client(self._client)
+        resolved_bucket = bucket or require_config(self._config).minio_output_bucket
 
         try:
             response = client.get_object(resolved_bucket, object_path)
@@ -174,27 +175,6 @@ class WorkbenchMinioClient:
 
         return content
 
-    def get_child_task_id(self, parent_task_id: str, tre: str) -> str:
-        """
-        Get the child task ID for a given task and TRE.
-        """
-        response = requests.get(
-            f"{self._config.tes_base_url.rstrip('/')}/api/Submission/GetChildSubmissionIdByParentAndTre?parentSubmissionId={parent_task_id}&treName={tre}"
-        )
-        response.raise_for_status()
-        if response.status_code != 200:
-            raise RuntimeError(
-                f"Failed to get child task ID: {response.status_code} {response.text}"
-            )
-
-        child_task_id = response.json()
-        if child_task_id is None:
-            raise RuntimeError(
-                f"No child task ID found for parent task {parent_task_id} and TRE {tre}"
-            )
-        logger.info("Child task ID: %s", child_task_id)
-        return child_task_id
-
     def fetch_result(
         self, task_id: str, bucket: str | None = None
     ) -> dict[str, str | dict[str, Any] | list[Any] | None]:
@@ -222,26 +202,6 @@ class WorkbenchMinioClient:
             results[path] = self._parse_result(path, bucket=bucket)
 
         return results
-
-    # ------------------------------------------------------------------
-    # Private helpers
-    # ------------------------------------------------------------------
-
-    def _require_client(self) -> Minio:
-        if self._client is None:
-            raise ValueError(
-                "MinIO client is not initialised. "
-                "Please call fetch_results() after submit()."
-            )
-        return self._client
-
-    def _require_config(self) -> ConfigValidationModel:
-        if self._config is None:
-            raise ValueError(
-                "MinIO builder has no config. "
-                "Please call fetch_results() after submit()."
-            )
-        return self._config
 
     @staticmethod
     def _exchange_token(bearer: str, sts_endpoint: str) -> dict[str, str]:
@@ -288,17 +248,3 @@ class WorkbenchMinioClient:
             )
             or "",
         }
-
-
-# ------------------------------------------------------------------
-# Module-level helper
-# ------------------------------------------------------------------
-
-
-def _is_https(url: str) -> bool:
-    parsed = urlparse(url)
-    if parsed.scheme == "https":
-        return True
-    if parsed.scheme == "http":
-        return False
-    raise ValueError(f"URL must start with http:// or https://, got: {url!r}")

--- a/src/five_safes_tes_workbench/core/minio_client.py
+++ b/src/five_safes_tes_workbench/core/minio_client.py
@@ -5,8 +5,9 @@ import requests
 from minio import Minio
 import xml.etree.ElementTree as ET
 
-from ..helpers.minio import is_https, list_results, get_and_parse_result
+from ..helpers.minio import list_results, get_and_parse_result
 from ..helpers.auth import resolve_bearer
+from ..helpers.url import is_https
 from ..schema.config_schema import ConfigValidationModel
 from ..schema.auth_schema import AuthValidationModel
 from ..utils.logger import get_logger

--- a/src/five_safes_tes_workbench/core/minio_client.py
+++ b/src/five_safes_tes_workbench/core/minio_client.py
@@ -10,7 +10,7 @@ from ..helpers.minio import (
     exchange_minio_token,
 )
 from ..helpers.auth import resolve_bearer
-from ..helpers.url import is_https
+from ..helpers.url import is_https, strip_scheme
 from ..schema.config_schema import ConfigValidationModel
 from ..schema.auth_schema import AuthValidationModel
 from ..utils.logger import get_logger
@@ -43,10 +43,11 @@ class MinioClientBuilder:
         """
         bearer = resolve_bearer(auth)
         credentials = exchange_minio_token(bearer, config.minio_sts_endpoint)
-        # Check if the MinIO endpoint is HTTPS
         secure = is_https(config.minio_endpoint)
+        # Minio() only accepts host:port — strip any http(s):// prefix.
+        endpoint = strip_scheme(config.minio_endpoint)
         self._client = Minio(
-            config.minio_endpoint,
+            endpoint,
             access_key=credentials.access_key,
             secret_key=credentials.secret_key,
             session_token=credentials.session_token,

--- a/src/five_safes_tes_workbench/core/minio_client.py
+++ b/src/five_safes_tes_workbench/core/minio_client.py
@@ -125,17 +125,19 @@ class MinioClientBuilder:
         if credentials is None:
             raise RuntimeError("STS response contained no Credentials element")
 
+        access_key = credentials.findtext("sts:AccessKeyId", namespaces=STS_NAMESPACE)
+        secret_key = credentials.findtext(
+            "sts:SecretAccessKey", namespaces=STS_NAMESPACE
+        )
+        session_token = credentials.findtext(
+            "sts:SessionToken", namespaces=STS_NAMESPACE
+        )
+
+        if access_key is None or secret_key is None or session_token is None:
+            raise RuntimeError("STS response did not contain all required credentials")
+
         return {
-            "access_key": credentials.findtext(
-                "sts:AccessKeyId", namespaces=STS_NAMESPACE
-            )
-            or "",
-            "secret_key": credentials.findtext(
-                "sts:SecretAccessKey", namespaces=STS_NAMESPACE
-            )
-            or "",
-            "session_token": credentials.findtext(
-                "sts:SessionToken", namespaces=STS_NAMESPACE
-            )
-            or "",
+            "access_key": access_key,
+            "secret_key": secret_key,
+            "session_token": session_token,
         }

--- a/src/five_safes_tes_workbench/core/minio_client.py
+++ b/src/five_safes_tes_workbench/core/minio_client.py
@@ -1,17 +1,8 @@
 """Builder responsible for fetching task results from MinIO after submission."""
 
 from typing import Any
-import requests
 from minio import Minio
-import xml.etree.ElementTree as ET
-
-from ..constants.minio import (
-    STS_DURATION_SECONDS,
-    STS_NAMESPACE,
-    STS_TOKEN_EXCHANGE_TIMEOUT,
-)
-
-from ..helpers.minio import list_results, get_and_parse_result
+from ..helpers.minio import list_results, get_and_parse_result, exchange_minio_token
 from ..helpers.auth import resolve_bearer
 from ..helpers.url import is_https
 from ..schema.config_schema import ConfigValidationModel
@@ -45,14 +36,14 @@ class MinioClientBuilder:
           token.
         """
         bearer = resolve_bearer(auth)
-        credentials = self._exchange_token(bearer, config.minio_sts_endpoint)
+        credentials = exchange_minio_token(bearer, config.minio_sts_endpoint)
 
         secure = is_https(config.minio_sts_endpoint)
         self._client = Minio(
             config.minio_endpoint,
-            access_key=credentials["access_key"],
-            secret_key=credentials["secret_key"],
-            session_token=credentials["session_token"],
+            access_key=credentials.access_key,
+            secret_key=credentials.secret_key,
+            session_token=credentials.session_token,
             secure=secure,
         )
         self._config = config
@@ -91,53 +82,3 @@ class MinioClientBuilder:
             )
 
         return results
-
-    @staticmethod
-    def _exchange_token(bearer: str, sts_endpoint: str) -> dict[str, str]:
-        """
-        Call the STS AssumeRoleWithWebIdentity action and return temporary
-        AWS-style credentials.
-        """
-        logger.info(
-            "Exchanging bearer token for MinIO credentials via STS (%s)", sts_endpoint
-        )
-
-        response = requests.post(
-            sts_endpoint,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-            data={
-                "Action": "AssumeRoleWithWebIdentity",
-                "Version": "2011-06-15",
-                "DurationSeconds": STS_DURATION_SECONDS,
-                "WebIdentityToken": bearer,
-            },
-            timeout=STS_TOKEN_EXCHANGE_TIMEOUT,
-        )
-
-        if response.status_code != 200:
-            raise RuntimeError(
-                f"STS token exchange failed ({response.status_code}): {response.text}"
-            )
-
-        root = ET.fromstring(response.text)
-        credentials = root.find(".//sts:Credentials", STS_NAMESPACE)
-
-        if credentials is None:
-            raise RuntimeError("STS response contained no Credentials element")
-
-        access_key = credentials.findtext("sts:AccessKeyId", namespaces=STS_NAMESPACE)
-        secret_key = credentials.findtext(
-            "sts:SecretAccessKey", namespaces=STS_NAMESPACE
-        )
-        session_token = credentials.findtext(
-            "sts:SessionToken", namespaces=STS_NAMESPACE
-        )
-
-        if access_key is None or secret_key is None or session_token is None:
-            raise RuntimeError("STS response did not contain all required credentials")
-
-        return {
-            "access_key": access_key,
-            "secret_key": secret_key,
-            "session_token": session_token,
-        }

--- a/src/five_safes_tes_workbench/core/minio_client.py
+++ b/src/five_safes_tes_workbench/core/minio_client.py
@@ -27,18 +27,8 @@ class MinioClientBuilder:
     configured STS endpoint (AssumeRoleWithWebIdentity).
     """
 
-    def __init__(self) -> None:
-        self._client: Minio | None = None
-        self._config: ConfigValidationModel | None = None
-
-    # ------------------------------------------------------------------
-    # Initialisation
-    # ------------------------------------------------------------------
-
-    def initialise(
-        self,
-        config: ConfigValidationModel,
-        auth: AuthValidationModel,
+    def __init__(
+        self, config: ConfigValidationModel, auth: AuthValidationModel
     ) -> None:
         """
         Exchange the bearer token for temporary MinIO credentials via STS
@@ -55,7 +45,6 @@ class MinioClientBuilder:
         credentials = self._exchange_token(bearer, config.minio_sts_endpoint)
 
         secure = is_https(config.minio_sts_endpoint)
-
         self._client = Minio(
             config.minio_endpoint,
             access_key=credentials["access_key"],
@@ -64,16 +53,11 @@ class MinioClientBuilder:
             secure=secure,
         )
         self._config = config
-
         logger.info(
             "MinIO client initialised (endpoint=%s, secure=%s)",
             config.minio_endpoint,
             secure,
         )
-
-    # ------------------------------------------------------------------
-    # Public result-fetching methods
-    # ------------------------------------------------------------------
 
     def fetch_result(
         self, task_id: str, bucket: str | None = None

--- a/src/five_safes_tes_workbench/core/minio_client.py
+++ b/src/five_safes_tes_workbench/core/minio_client.py
@@ -1,8 +1,14 @@
 """Builder responsible for fetching task results from MinIO after submission."""
 
+from pathlib import Path
 from typing import Any
 from minio import Minio
-from ..helpers.minio import list_results, get_and_parse_result, exchange_minio_token
+from ..helpers.minio import (
+    list_results,
+    get_and_parse_result,
+    download_result,
+    exchange_minio_token,
+)
 from ..helpers.auth import resolve_bearer
 from ..helpers.url import is_https
 from ..schema.config_schema import ConfigValidationModel
@@ -82,3 +88,39 @@ class MinioClientBuilder:
             )
 
         return results
+
+    def download_results(
+        self,
+        task_id: str,
+        output_dir: Path,
+        bucket: str | None = None,
+    ) -> list[Path]:
+        """
+        Download all output objects for a task to a local directory.
+
+        Each object is written to ``output_dir/<filename>``, stripping the
+        leading ``<task_id>/`` prefix that MinIO uses as a folder separator.
+
+        Parameters
+        ----------
+        - task_id: ID returned by the TES submission.
+        - output_dir: Local directory to write the downloaded files into.
+          The directory (and any missing parents) is created automatically.
+        - bucket: Override the bucket from config.
+
+        Returns
+        -------
+        List of :class:`~pathlib.Path` objects pointing to every downloaded
+        file.
+        """
+        object_paths = list_results(self._client, self._config, task_id, bucket=bucket)
+
+        downloaded: list[Path] = []
+        for path in object_paths:
+            logger.info("Downloading result object: %s", path)
+            local_path = download_result(
+                self._client, self._config, path, output_dir, bucket=bucket
+            )
+            downloaded.append(local_path)
+
+        return downloaded

--- a/src/five_safes_tes_workbench/core/minio_client.py
+++ b/src/five_safes_tes_workbench/core/minio_client.py
@@ -5,6 +5,12 @@ import requests
 from minio import Minio
 import xml.etree.ElementTree as ET
 
+from ..constants.minio import (
+    STS_DURATION_SECONDS,
+    STS_NAMESPACE,
+    STS_TOKEN_EXCHANGE_TIMEOUT,
+)
+
 from ..helpers.minio import list_results, get_and_parse_result
 from ..helpers.auth import resolve_bearer
 from ..helpers.url import is_https
@@ -13,9 +19,6 @@ from ..schema.auth_schema import AuthValidationModel
 from ..utils.logger import get_logger
 
 logger = get_logger(__name__)
-
-_STS_NS = {"sts": "https://sts.amazonaws.com/doc/2011-06-15/"}
-_STS_DURATION_SECONDS = "3600"
 
 
 class MinioClientBuilder:
@@ -105,10 +108,10 @@ class MinioClientBuilder:
             data={
                 "Action": "AssumeRoleWithWebIdentity",
                 "Version": "2011-06-15",
-                "DurationSeconds": _STS_DURATION_SECONDS,
+                "DurationSeconds": STS_DURATION_SECONDS,
                 "WebIdentityToken": bearer,
             },
-            timeout=30,
+            timeout=STS_TOKEN_EXCHANGE_TIMEOUT,
         )
 
         if response.status_code != 200:
@@ -117,20 +120,22 @@ class MinioClientBuilder:
             )
 
         root = ET.fromstring(response.text)
-        credentials = root.find(".//sts:Credentials", _STS_NS)
+        credentials = root.find(".//sts:Credentials", STS_NAMESPACE)
 
         if credentials is None:
             raise RuntimeError("STS response contained no Credentials element")
 
         return {
-            "access_key": credentials.findtext("sts:AccessKeyId", namespaces=_STS_NS)
+            "access_key": credentials.findtext(
+                "sts:AccessKeyId", namespaces=STS_NAMESPACE
+            )
             or "",
             "secret_key": credentials.findtext(
-                "sts:SecretAccessKey", namespaces=_STS_NS
+                "sts:SecretAccessKey", namespaces=STS_NAMESPACE
             )
             or "",
             "session_token": credentials.findtext(
-                "sts:SessionToken", namespaces=_STS_NS
+                "sts:SessionToken", namespaces=STS_NAMESPACE
             )
             or "",
         }

--- a/src/five_safes_tes_workbench/core/minio_client.py
+++ b/src/five_safes_tes_workbench/core/minio_client.py
@@ -1,17 +1,11 @@
 """Builder responsible for fetching task results from MinIO after submission."""
 
-import json
-import csv
-import xml.etree.ElementTree as ET
-from io import StringIO
 from typing import Any
-
 import requests
 from minio import Minio
-import minio
+import xml.etree.ElementTree as ET
 
-from ..helpers.minio import is_https, require_client, require_config
-
+from ..helpers.minio import is_https, list_results, get_and_parse_result
 from ..schema.config_schema import ConfigValidationModel
 from ..schema.auth_schema import AuthValidationModel
 from ..core.submit_builder import WorkbenchSubmitBuilder
@@ -80,101 +74,6 @@ class WorkbenchMinioClient:
     # Public result-fetching methods
     # ------------------------------------------------------------------
 
-    def list_results(self, task_id: str, bucket: str | None = None) -> list[str]:
-        """
-        List all output objects written by a task.
-
-        Objects are expected to live under the ``{task_id}/`` prefix in the
-        configured output bucket.
-
-        Parameters
-        ----------
-        - task_id: ID returned by the TES submission.
-        - bucket: Override the bucket from config. Defaults to
-          ``config.minio_output_bucket``.
-
-        Returns
-        -------
-        List of object names found under the task prefix.
-        """
-        client = require_client(self._client)
-        resolved_bucket = bucket or require_config(self._config).minio_output_bucket
-        prefix = f"{task_id}/"
-
-        try:
-            objects = client.list_objects(
-                resolved_bucket, prefix=prefix, recursive=True
-            )
-            names = [obj.object_name for obj in objects]
-            logger.info("Found %d result object(s) for task %s", len(names), task_id)
-            return names
-        except Exception as e:
-            logger.error("Error listing results for task %s: %s", task_id, e)
-            raise
-
-    def get_result(self, object_path: str, bucket: str | None = None) -> str | None:
-        """
-        Fetch a single result object as a raw UTF-8 string.
-
-        Parameters
-        ----------
-        - object_path: Full object path within the bucket (e.g.
-          ``"<task_id>/stdout"``)
-        - bucket: Override the bucket from config.
-
-        Returns
-        -------
-        String content of the object, or ``None`` if the object does not
-        exist.
-        """
-        client = require_client(self._client)
-        resolved_bucket = bucket or require_config(self._config).minio_output_bucket
-
-        try:
-            response = client.get_object(resolved_bucket, object_path)
-            content = response.read().decode("utf-8")
-            response.close()
-            response.release_conn()
-            return content
-        except minio.error.S3Error as e:
-            if e.code == "NoSuchKey":
-                logger.warning("Object not found: %s", object_path)
-                return None
-            raise
-
-    def _parse_result(
-        self, object_path: str, bucket: str | None = None
-    ) -> str | dict[str, Any] | list[Any] | None:
-        """
-        Fetch a single result object and auto-detect its format.
-
-        Attempts JSON first, then CSV (returning the first row as a dict),
-        then falls back to a raw string.
-
-        Parameters
-        ----------
-        - object_path: Full object path within the bucket.
-        - bucket: Override the bucket from config.
-        """
-        content = self.get_result(object_path, bucket=bucket)
-        if content is None:
-            return None
-
-        try:
-            return json.loads(content)
-        except json.JSONDecodeError:
-            pass
-
-        try:
-            reader = csv.DictReader(StringIO(content))
-            rows = list(reader)
-            if rows:
-                return rows
-        except Exception:
-            pass
-
-        return content
-
     def fetch_result(
         self, task_id: str, bucket: str | None = None
     ) -> dict[str, str | dict[str, Any] | list[Any] | None]:
@@ -194,12 +93,14 @@ class WorkbenchMinioClient:
         -------
         Dict mapping each object path to its parsed content.
         """
-        object_paths = self.list_results(task_id, bucket=bucket)
+        object_paths = list_results(self._client, self._config, task_id, bucket=bucket)
 
         results: dict[str, str | dict[str, Any] | list[Any] | None] = {}
         for path in object_paths:
             logger.info("Fetching result object: %s", path)
-            results[path] = self._parse_result(path, bucket=bucket)
+            results[path] = get_and_parse_result(
+                self._client, self._config, path, bucket=bucket
+            )
 
         return results
 

--- a/src/five_safes_tes_workbench/core/submit_builder.py
+++ b/src/five_safes_tes_workbench/core/submit_builder.py
@@ -1,4 +1,6 @@
 import requests
+
+from ..helpers.auth import fetch_keycloak_token, resolve_bearer
 from ..utils.logger import get_logger
 
 from ..schema.config_schema import ConfigValidationModel
@@ -29,7 +31,7 @@ class WorkbenchSubmitBuilder:
     ) -> str:
         """
         Submits the given TES task to the configured TES endpoint.
-        
+
         Attributes:
              - `config`: Validated configuration containing TES endpoint
                and other settings.
@@ -38,17 +40,17 @@ class WorkbenchSubmitBuilder:
                the TES endpoint.
 
              - `task`: The TES task to be submitted.
-             
+
         Returns:
              - The ID of the submitted task.
-             
+
         """
 
         _task_json: str = task.as_json()  # type: ignore[reportUnknownMemberType]
 
         base_url = config.tes_base_url.rstrip("/")
         endpoint = f"{base_url}/v1/tasks"
-        bearer = self._resolve_bearer(auth)
+        bearer = resolve_bearer(auth)
 
         logger.info("Submitting task to %s/v1/tasks", base_url)
 
@@ -56,7 +58,7 @@ class WorkbenchSubmitBuilder:
 
         if response.status_code == 401 and auth.auth_mode == AuthMode.CREDENTIALS:
             logger.info("Received 401, retrying with fresh keycloak token...")
-            bearer = self._fetch_keycloak_token(auth)
+            bearer = fetch_keycloak_token(auth)
             response = self._post_task(endpoint, _task_json, bearer)
 
         response.raise_for_status()
@@ -73,12 +75,12 @@ class WorkbenchSubmitBuilder:
     ) -> requests.Response:
         """
         Helper method to post the task to the TES endpoint.
-        
+
         Attributes:
              - `endpoint`: The full URL of the TES endpoint to submit to.
              - `task_json`: The TES task serialized as a JSON string.
              - `bearer`: The bearer token for authentication.
-        
+
         Returns:
              - The HTTP response from the TES endpoint.
         """
@@ -91,67 +93,3 @@ class WorkbenchSubmitBuilder:
             },
             timeout=60,
         )
-
-    @staticmethod
-    def _resolve_bearer(auth: AuthValidationModel) -> str:
-        """
-        Helper for resolving the bearer token based on
-        the authentication mode.
-
-        - If the mode is ACCESS_TOKEN, it uses the provided token.
-
-        - If the mode is CREDENTIALS, it fetches a new token from Keycloak.
-
-        Attributes:
-                - `auth`: The authentication details containing
-                mode and credentials.
-        """
-        if auth.auth_mode == AuthMode.ACCESS_TOKEN:
-            if auth.access_token is None:
-                raise ValueError(
-                    "access_token is required when auth_mode is ACCESS_TOKEN"
-                )
-
-            logger.info("Using provided access token")
-            return auth.access_token
-
-        logger.info("Fetching token from keycloak...")
-        return WorkbenchSubmitBuilder._fetch_keycloak_token(auth)
-
-    @staticmethod
-    def _fetch_keycloak_token(auth: AuthValidationModel) -> str:
-        """
-        Helper method to fetch a new access token from 
-        Keycloak using the provided credentials.
-        
-        Attributes:
-             - `auth`: The authentication details containing
-            Keycloak credentials.
-             
-        Returns:
-             - The access token fetched from Keycloak.
-        """
-        url = (
-            f"{auth.keycloak_url.rstrip('/')}"  # type: ignore[union-attr]
-            f"/realms/Dare-Control/protocol/openid-connect/token"
-        )
-
-        logger.info("Requesting keycloak token from %s", url)
-
-        response = requests.post(
-            url,
-            data={
-                "client_id": auth.client_id,
-                "client_secret": auth.client_secret,
-                "username": auth.username,
-                "password": auth.password,
-                "grant_type": "password",
-            },
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-            timeout=30,
-        )
-
-        response.raise_for_status()
-
-        logger.info("Keycloak token fetched successfully")
-        return response.json()["access_token"]

--- a/src/five_safes_tes_workbench/core/validate_builder.py
+++ b/src/five_safes_tes_workbench/core/validate_builder.py
@@ -37,7 +37,7 @@ class WorkbenchValidateBuilder:
         Returns the validated infrastructure configuration.
         """
         if self._config is None:
-            raise ValueError("Before building the TES message, please call the function validate().")
+            raise ValueError("Before building the TES message or fetching results, please call the function validate().")
         return self._config
 
     @property

--- a/src/five_safes_tes_workbench/helpers/auth.py
+++ b/src/five_safes_tes_workbench/helpers/auth.py
@@ -1,0 +1,68 @@
+import requests
+from ..schema.auth_schema import AuthValidationModel
+from ..common.validator_enums import AuthMode
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def fetch_keycloak_token(auth: AuthValidationModel) -> str:
+    """
+    Helper method to fetch a new access token from
+    Keycloak using the provided credentials.
+
+    Attributes:
+            - `auth`: The authentication details containing
+        Keycloak credentials.
+
+    Returns:
+            - The access token fetched from Keycloak.
+    """
+    url = (
+        f"{auth.keycloak_url.rstrip('/')}"  # type: ignore[union-attr]
+        f"/realms/Dare-Control/protocol/openid-connect/token"
+    )
+
+    logger.info("Requesting keycloak token from %s", url)
+
+    response = requests.post(
+        url,
+        data={
+            "client_id": auth.client_id,
+            "client_secret": auth.client_secret,
+            "username": auth.username,
+            "password": auth.password,
+            "grant_type": "password",
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        timeout=30,
+    )
+
+    response.raise_for_status()
+
+    logger.info("Keycloak token fetched successfully")
+    return response.json()["access_token"]
+
+
+def resolve_bearer(auth: AuthValidationModel) -> str:
+    """
+    Helper for resolving the bearer token based on
+    the authentication mode.
+
+    - If the mode is ACCESS_TOKEN, it uses the provided token.
+
+    - If the mode is CREDENTIALS, it fetches a new token from Keycloak.
+
+    Attributes:
+            - `auth`: The authentication details containing
+            mode and credentials.
+    """
+    if auth.auth_mode == AuthMode.ACCESS_TOKEN:
+        if auth.access_token is None:
+            raise ValueError("access_token is required when auth_mode is ACCESS_TOKEN")
+
+        logger.info("Using provided access token")
+        return auth.access_token
+
+    logger.info("Fetching token from keycloak...")
+    return fetch_keycloak_token(auth)

--- a/src/five_safes_tes_workbench/helpers/children_task.py
+++ b/src/five_safes_tes_workbench/helpers/children_task.py
@@ -54,7 +54,7 @@ def get_child_task_info(
     )
 
 
-def check_child_task_status(child_task_info: ChildTaskInfo) -> str | None:
+def validate_child_task_status(child_task_info: ChildTaskInfo) -> None:
     """
     Check the status of a child task and return an error message if the task is not completed.
 
@@ -71,10 +71,11 @@ def check_child_task_status(child_task_info: ChildTaskInfo) -> str | None:
         or child_task_info.status == TaskStatus.CANCELLED
         or child_task_info.status == TaskStatus.FAILURE
     ):
-        return (
+        raise RuntimeError(
             f"Child task {child_task_info.id} is failed or cancelled. Please try again."
         )
 
     elif child_task_info.status != TaskStatus.COMPLETED:
-        return f"Child task {child_task_info.id} is not completed, so results are not available yet. Please wait for the task to complete and try again. Current status: {TASK_STATUS_DESCRIPTIONS[TaskStatus(child_task_info.status)]}"
-    return None
+        raise RuntimeError(
+            f"Child task {child_task_info.id} is not completed or failed, so results are not available yet. Current status: {TASK_STATUS_DESCRIPTIONS[TaskStatus(child_task_info.status)]}"
+        )

--- a/src/five_safes_tes_workbench/helpers/children_task.py
+++ b/src/five_safes_tes_workbench/helpers/children_task.py
@@ -1,0 +1,79 @@
+from dataclasses import dataclass
+import requests
+from ..schema.config_schema import ConfigValidationModel
+from ..utils.logger import get_logger
+from ..constants.task_status import TASK_STATUS_DESCRIPTIONS, TaskStatus
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class ChildTaskInfo:
+    """
+    Information about a child task.
+
+    Attributes:
+    -----------
+    - id: The ID of the child task.
+    - status: The status of the child task.
+    """
+
+    id: str
+    status: TaskStatus
+
+
+def get_child_task_info(
+    config: ConfigValidationModel, parent_task_id: str, tre: str
+) -> ChildTaskInfo:
+    """
+    Get the child task ID for a given task and TRE.
+    """
+    response = requests.get(
+        f"{config.tes_base_url.rstrip('/')}/api/Submission/GetChildSubmissionInfoByParentAndTre?parentSubmissionId={parent_task_id}&treName={tre}"
+    )
+    response.raise_for_status()
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"Failed to get child task ID: {response.status_code} {response.text}"
+        )
+
+    child_task_info = response.json()
+    if child_task_info is None:
+        raise RuntimeError(
+            f"No child task ID found for parent task {parent_task_id} and TRE {tre}"
+        )
+    logger.info(
+        "Child task ID: %s, status: %s",
+        child_task_info["id"],
+        TASK_STATUS_DESCRIPTIONS[TaskStatus(child_task_info["status"])],
+    )
+    return ChildTaskInfo(
+        id=child_task_info["id"],
+        status=TaskStatus(child_task_info["status"]),
+    )
+
+
+def check_child_task_status(child_task_info: ChildTaskInfo) -> str | None:
+    """
+    Check the status of a child task and return an error message if the task is not completed.
+
+    Parameters
+    ----------
+    - child_task_info: The child task information.
+
+    Returns
+    -------
+    An error message if the task is not completed, failed or cancelled, otherwise None.
+    """
+    if (
+        child_task_info.status == TaskStatus.FAILED
+        or child_task_info.status == TaskStatus.CANCELLED
+        or child_task_info.status == TaskStatus.FAILURE
+    ):
+        return (
+            f"Child task {child_task_info.id} is failed or cancelled. Please try again."
+        )
+
+    elif child_task_info.status != TaskStatus.COMPLETED:
+        return f"Child task {child_task_info.id} is not completed, so results are not available yet. Please wait for the task to complete and try again. Current status: {TASK_STATUS_DESCRIPTIONS[TaskStatus(child_task_info.status)]}"
+    return None

--- a/src/five_safes_tes_workbench/helpers/children_task.py
+++ b/src/five_safes_tes_workbench/helpers/children_task.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from urllib.parse import urljoin
 import requests
 from ..schema.config_schema import ConfigValidationModel
 from ..utils.logger import get_logger
@@ -28,22 +29,22 @@ def get_child_task_info(
     """
     Get the child task ID for a given task and TRE.
     """
+    child_info_url = urljoin(
+        config.tes_base_url,
+        f"api/Submission/GetChildSubmissionInfoByParentAndTre?parentSubmissionId={parent_task_id}&treName={tre}",
+    )
     response = requests.get(
-        f"{config.tes_base_url.rstrip('/')}/api/Submission/GetChildSubmissionInfoByParentAndTre?parentSubmissionId={parent_task_id}&treName={tre}"
+        child_info_url,
     )
     response.raise_for_status()
-    if response.status_code != 200:
-        raise RuntimeError(
-            f"Failed to get child task ID: {response.status_code} {response.text}"
-        )
 
     child_task_info = response.json()
     if child_task_info is None:
         raise RuntimeError(
-            f"No child task ID found for parent task {parent_task_id} and TRE {tre}"
+            f"No child task info found for parent task {parent_task_id} and TRE {tre}"
         )
     logger.info(
-        "Child task ID: %s, status: %s",
+        "Child task info: %s, status: %s",
         child_task_info["id"],
         TASK_STATUS_DESCRIPTIONS[TaskStatus(child_task_info["status"])],
     )

--- a/src/five_safes_tes_workbench/helpers/minio.py
+++ b/src/five_safes_tes_workbench/helpers/minio.py
@@ -1,4 +1,9 @@
+import csv
+import json
+from typing import Any
+from io import StringIO
 from minio import Minio
+import minio
 import requests
 from ..schema.config_schema import ConfigValidationModel
 from urllib.parse import urlparse
@@ -55,3 +60,95 @@ def get_child_task_id(
         )
     logger.info("Child task ID: %s", child_task_id)
     return child_task_id
+
+
+def list_results(
+    client: Minio | None,
+    config: ConfigValidationModel | None,
+    task_id: str,
+    bucket: str | None = None,
+) -> list[str]:
+    """
+    List all output objects written by a task.
+
+    Objects are expected to live under the ``{task_id}/`` prefix in the
+    configured output bucket.
+
+    Parameters
+    ----------
+    - task_id: ID returned by the TES submission.
+    - bucket: Override the bucket from config. Defaults to
+        ``config.minio_output_bucket``.
+
+    Returns
+    -------
+    List of object names found under the task prefix.
+    """
+    client = require_client(client)
+    resolved_bucket = bucket or require_config(config).minio_output_bucket
+    prefix = f"{task_id}/"
+
+    try:
+        objects = client.list_objects(resolved_bucket, prefix=prefix, recursive=True)
+        names = [obj.object_name for obj in objects]
+        logger.info("Found %d result object(s) for task %s", len(names), task_id)
+        return names
+    except Exception as e:
+        logger.error("Error listing results for task %s: %s", task_id, e)
+        raise
+
+
+def get_and_parse_result(
+    client: Minio | None,
+    config: ConfigValidationModel | None,
+    object_path: str,
+    bucket: str | None = None,
+) -> str | dict[str, Any] | list[Any] | None:
+    """
+    Fetch a single result object and auto-detect its format.
+
+    Attempts JSON first, then CSV (returning the first row as a dict),
+    then falls back to a raw string.
+
+    Parameters
+    ----------
+    - object_path: Full object path within the bucket (e.g.
+        ``"<task_id>/stdout"``)
+    - bucket: Override the bucket from config.
+
+    Returns
+    -------
+    String content of the object, or ``None`` if the object does not
+    exist.
+    """
+    client = require_client(client)
+    resolved_bucket = bucket or require_config(config).minio_output_bucket
+
+    try:
+        response = client.get_object(resolved_bucket, object_path)
+        content = response.read().decode("utf-8")
+        response.close()
+        response.release_conn()
+
+        if content is None:
+            logger.warning("Object not found: %s", object_path)
+            return None
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError:
+            pass
+
+        try:
+            reader = csv.DictReader(StringIO(content))
+            rows = list(reader)
+            if rows:
+                return rows
+        except Exception:
+            pass
+        return content
+
+    except minio.error.S3Error as e:
+        if e.code == "NoSuchKey":
+            logger.warning("Object not found: %s", object_path)
+            return None
+        raise

--- a/src/five_safes_tes_workbench/helpers/minio.py
+++ b/src/five_safes_tes_workbench/helpers/minio.py
@@ -23,23 +23,6 @@ class ChildTaskInfo:
     status: TaskStatus
 
 
-def require_client(client: Minio | None) -> Minio:
-    if client is None:
-        raise ValueError(
-            "MinIO client is not initialised. "
-            "Please call fetch_results() after submit()."
-        )
-    return client
-
-
-def require_config(config: ConfigValidationModel | None) -> ConfigValidationModel:
-    if config is None:
-        raise ValueError(
-            "MinIO builder has no config. Please call fetch_results() after submit()."
-        )
-    return config
-
-
 def is_https(url: str) -> bool:
     parsed = urlparse(url)
     if parsed.scheme == "https":
@@ -107,8 +90,8 @@ def check_child_task_status(child_task_info: ChildTaskInfo) -> str | None:
 
 
 def list_results(
-    client: Minio | None,
-    config: ConfigValidationModel | None,
+    client: Minio,
+    config: ConfigValidationModel,
     task_id: str,
     bucket: str | None = None,
 ) -> list[str]:
@@ -123,13 +106,15 @@ def list_results(
     - task_id: ID returned by the TES submission.
     - bucket: Override the bucket from config. Defaults to
         ``config.minio_output_bucket``.
+    - client: MinIO client (should be already initialised before calling this function).
+    - config: ConfigValidationModel (should be already validated before calling this function).
 
     Returns
     -------
     List of object names found under the task prefix.
     """
-    client = require_client(client)
-    resolved_bucket = bucket or require_config(config).minio_output_bucket
+
+    resolved_bucket = bucket or config.minio_output_bucket
     prefix = f"{task_id}/"
 
     try:
@@ -143,8 +128,8 @@ def list_results(
 
 
 def get_and_parse_result(
-    client: Minio | None,
-    config: ConfigValidationModel | None,
+    client: Minio,
+    config: ConfigValidationModel,
     object_path: str,
     bucket: str | None = None,
 ) -> str | dict[str, Any] | list[Any] | None:
@@ -159,14 +144,16 @@ def get_and_parse_result(
     - object_path: Full object path within the bucket (e.g.
         ``"<task_id>/stdout"``)
     - bucket: Override the bucket from config.
+    - client: MinIO client (should be already initialised before calling this function).
+    - config: ConfigValidationModel (should be already validated before calling this function).
 
     Returns
     -------
     String content of the object, or ``None`` if the object does not
     exist.
     """
-    client = require_client(client)
-    resolved_bucket = bucket or require_config(config).minio_output_bucket
+
+    resolved_bucket = bucket or config.minio_output_bucket
 
     try:
         response = client.get_object(resolved_bucket, object_path)

--- a/src/five_safes_tes_workbench/helpers/minio.py
+++ b/src/five_safes_tes_workbench/helpers/minio.py
@@ -1,15 +1,26 @@
 import csv
 import json
+from dataclasses import dataclass
 from typing import Any
 from io import StringIO
 from minio import Minio
 import minio
 import requests
+from five_safes_tes_workbench.constants.task_status import (
+    TASK_STATUS_DESCRIPTIONS,
+    TaskStatus,
+)
 from ..schema.config_schema import ConfigValidationModel
 from urllib.parse import urlparse
 from ..utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+@dataclass
+class ChildTaskInfo:
+    id: str
+    status: TaskStatus
 
 
 def require_client(client: Minio | None) -> Minio:
@@ -38,14 +49,14 @@ def is_https(url: str) -> bool:
     raise ValueError(f"URL must start with http:// or https://, got: {url!r}")
 
 
-def get_child_task_id(
+def get_child_task_info(
     config: ConfigValidationModel, parent_task_id: str, tre: str
-) -> str:
+) -> ChildTaskInfo:
     """
     Get the child task ID for a given task and TRE.
     """
     response = requests.get(
-        f"{config.tes_base_url.rstrip('/')}/api/Submission/GetChildSubmissionIdByParentAndTre?parentSubmissionId={parent_task_id}&treName={tre}"
+        f"{config.tes_base_url.rstrip('/')}/api/Submission/GetChildSubmissionInfoByParentAndTre?parentSubmissionId={parent_task_id}&treName={tre}"
     )
     response.raise_for_status()
     if response.status_code != 200:
@@ -53,13 +64,46 @@ def get_child_task_id(
             f"Failed to get child task ID: {response.status_code} {response.text}"
         )
 
-    child_task_id = response.json()
-    if child_task_id is None:
+    child_task_info = response.json()
+    if child_task_info is None:
         raise RuntimeError(
             f"No child task ID found for parent task {parent_task_id} and TRE {tre}"
         )
-    logger.info("Child task ID: %s", child_task_id)
-    return child_task_id
+    logger.info(
+        "Child task ID: %s, status: %s",
+        child_task_info["id"],
+        TASK_STATUS_DESCRIPTIONS[TaskStatus(child_task_info["status"])],
+    )
+    return ChildTaskInfo(
+        id=child_task_info["id"],
+        status=TaskStatus(child_task_info["status"]),
+    )
+
+
+def check_child_task_status(child_task_info: ChildTaskInfo) -> str | None:
+    """
+    Check the status of a child task and return an error message if the task is not completed.
+
+    Parameters
+    ----------
+    - child_task_info: The child task information.
+
+    Returns
+    -------
+    An error message if the task is not completed, failed or cancelled, otherwise None.
+    """
+    if (
+        child_task_info.status == TaskStatus.FAILED
+        or child_task_info.status == TaskStatus.CANCELLED
+        or child_task_info.status == TaskStatus.FAILURE
+    ):
+        return (
+            f"Child task {child_task_info.id} is failed or cancelled. Please try again."
+        )
+
+    elif child_task_info.status != TaskStatus.COMPLETED:
+        return f"Child task {child_task_info.id} is not completed, so results are not available yet. Please wait for the task to complete and try again. Current status: {TASK_STATUS_DESCRIPTIONS[TaskStatus(child_task_info.status)]}"
+    return None
 
 
 def list_results(

--- a/src/five_safes_tes_workbench/helpers/minio.py
+++ b/src/five_safes_tes_workbench/helpers/minio.py
@@ -1,92 +1,13 @@
 import csv
 import json
-from dataclasses import dataclass
 from typing import Any
 from io import StringIO
 from minio import Minio
 import minio
-import requests
-from five_safes_tes_workbench.constants.task_status import (
-    TASK_STATUS_DESCRIPTIONS,
-    TaskStatus,
-)
 from ..schema.config_schema import ConfigValidationModel
-from urllib.parse import urlparse
 from ..utils.logger import get_logger
 
 logger = get_logger(__name__)
-
-
-@dataclass
-class ChildTaskInfo:
-    id: str
-    status: TaskStatus
-
-
-def is_https(url: str) -> bool:
-    parsed = urlparse(url)
-    if parsed.scheme == "https":
-        return True
-    if parsed.scheme == "http":
-        return False
-    raise ValueError(f"URL must start with http:// or https://, got: {url!r}")
-
-
-def get_child_task_info(
-    config: ConfigValidationModel, parent_task_id: str, tre: str
-) -> ChildTaskInfo:
-    """
-    Get the child task ID for a given task and TRE.
-    """
-    response = requests.get(
-        f"{config.tes_base_url.rstrip('/')}/api/Submission/GetChildSubmissionInfoByParentAndTre?parentSubmissionId={parent_task_id}&treName={tre}"
-    )
-    response.raise_for_status()
-    if response.status_code != 200:
-        raise RuntimeError(
-            f"Failed to get child task ID: {response.status_code} {response.text}"
-        )
-
-    child_task_info = response.json()
-    if child_task_info is None:
-        raise RuntimeError(
-            f"No child task ID found for parent task {parent_task_id} and TRE {tre}"
-        )
-    logger.info(
-        "Child task ID: %s, status: %s",
-        child_task_info["id"],
-        TASK_STATUS_DESCRIPTIONS[TaskStatus(child_task_info["status"])],
-    )
-    return ChildTaskInfo(
-        id=child_task_info["id"],
-        status=TaskStatus(child_task_info["status"]),
-    )
-
-
-def check_child_task_status(child_task_info: ChildTaskInfo) -> str | None:
-    """
-    Check the status of a child task and return an error message if the task is not completed.
-
-    Parameters
-    ----------
-    - child_task_info: The child task information.
-
-    Returns
-    -------
-    An error message if the task is not completed, failed or cancelled, otherwise None.
-    """
-    if (
-        child_task_info.status == TaskStatus.FAILED
-        or child_task_info.status == TaskStatus.CANCELLED
-        or child_task_info.status == TaskStatus.FAILURE
-    ):
-        return (
-            f"Child task {child_task_info.id} is failed or cancelled. Please try again."
-        )
-
-    elif child_task_info.status != TaskStatus.COMPLETED:
-        return f"Child task {child_task_info.id} is not completed, so results are not available yet. Please wait for the task to complete and try again. Current status: {TASK_STATUS_DESCRIPTIONS[TaskStatus(child_task_info.status)]}"
-    return None
 
 
 def list_results(

--- a/src/five_safes_tes_workbench/helpers/minio.py
+++ b/src/five_safes_tes_workbench/helpers/minio.py
@@ -1,0 +1,57 @@
+from minio import Minio
+import requests
+from ..schema.config_schema import ConfigValidationModel
+from urllib.parse import urlparse
+from ..utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def require_client(client: Minio | None) -> Minio:
+    if client is None:
+        raise ValueError(
+            "MinIO client is not initialised. "
+            "Please call fetch_results() after submit()."
+        )
+    return client
+
+
+def require_config(config: ConfigValidationModel | None) -> ConfigValidationModel:
+    if config is None:
+        raise ValueError(
+            "MinIO builder has no config. Please call fetch_results() after submit()."
+        )
+    return config
+
+
+def is_https(url: str) -> bool:
+    parsed = urlparse(url)
+    if parsed.scheme == "https":
+        return True
+    if parsed.scheme == "http":
+        return False
+    raise ValueError(f"URL must start with http:// or https://, got: {url!r}")
+
+
+def get_child_task_id(
+    config: ConfigValidationModel, parent_task_id: str, tre: str
+) -> str:
+    """
+    Get the child task ID for a given task and TRE.
+    """
+    response = requests.get(
+        f"{config.tes_base_url.rstrip('/')}/api/Submission/GetChildSubmissionIdByParentAndTre?parentSubmissionId={parent_task_id}&treName={tre}"
+    )
+    response.raise_for_status()
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"Failed to get child task ID: {response.status_code} {response.text}"
+        )
+
+    child_task_id = response.json()
+    if child_task_id is None:
+        raise RuntimeError(
+            f"No child task ID found for parent task {parent_task_id} and TRE {tre}"
+        )
+    logger.info("Child task ID: %s", child_task_id)
+    return child_task_id

--- a/src/five_safes_tes_workbench/helpers/minio.py
+++ b/src/five_safes_tes_workbench/helpers/minio.py
@@ -1,6 +1,7 @@
 import csv
 from dataclasses import dataclass
 import json
+from pathlib import Path
 from typing import Any
 from io import StringIO
 from minio import Minio
@@ -130,6 +131,53 @@ def get_and_parse_result(
             logger.warning("Object not found: %s", object_path)
             return None
         raise
+
+
+def download_result(
+    client: Minio,
+    config: ConfigValidationModel,
+    object_path: str,
+    output_dir: Path,
+    bucket: str | None = None,
+) -> Path:
+    """
+    Download a single result object from MinIO to a local file.
+
+    The ``<task_id>/`` prefix is stripped from ``object_path`` so that
+    only the filename (and any sub-path) is preserved under ``output_dir``.
+
+    Parameters
+    ----------
+    - client: Authenticated MinIO client.
+    - config: Validated infrastructure configuration.
+    - object_path: Full object path within the bucket (e.g.
+        ``"<task_id>/output.csv"``).
+    - output_dir: Local directory to write the file into.
+    - bucket: Override the bucket from config.
+
+    Returns
+    -------
+    The :class:`~pathlib.Path` of the downloaded local file.
+    """
+    resolved_bucket = bucket or config.minio_output_bucket
+
+    # Strip the leading <task_id>/ prefix so the filename is clean.
+    parts = object_path.split("/", 1)
+    relative_name = parts[1] if len(parts) > 1 else object_path
+
+    local_path = output_dir / relative_name
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        client.fget_object(resolved_bucket, object_path, str(local_path))
+        logger.info("Downloaded %s -> %s", object_path, local_path)
+    except minio.error.S3Error as e:
+        if e.code == "NoSuchKey":
+            logger.warning("Object not found, skipping: %s", object_path)
+            raise
+        raise
+
+    return local_path
 
 
 def _parse_sts_response(response: requests.Response) -> MinioCredentials:

--- a/src/five_safes_tes_workbench/helpers/minio.py
+++ b/src/five_safes_tes_workbench/helpers/minio.py
@@ -1,9 +1,5 @@
-import csv
 from dataclasses import dataclass
-import json
 from pathlib import Path
-from typing import Any
-from io import StringIO
 from minio import Minio
 import minio
 import requests
@@ -72,64 +68,6 @@ def list_results(
         return names
     except Exception as e:
         logger.error("Error listing results for task %s: %s", task_id, e)
-        raise
-
-
-def get_and_parse_result(
-    client: Minio,
-    config: ConfigValidationModel,
-    object_path: str,
-    bucket: str | None = None,
-) -> str | dict[str, Any] | list[Any] | None:
-    """
-    Fetch a single result object and auto-detect its format.
-
-    Attempts JSON first, then CSV (returning the first row as a dict),
-    then falls back to a raw string.
-
-    Parameters
-    ----------
-    - object_path: Full object path within the bucket (e.g.
-        ``"<task_id>/stdout"``)
-    - bucket: Override the bucket from config.
-    - client: MinIO client (should be already initialised before calling this function).
-    - config: ConfigValidationModel (should be already validated before calling this function).
-
-    Returns
-    -------
-    String content of the object, or ``None`` if the object does not
-    exist.
-    """
-
-    resolved_bucket = bucket or config.minio_output_bucket
-
-    try:
-        response = client.get_object(resolved_bucket, object_path)
-        content = response.read().decode("utf-8")
-        response.close()
-        response.release_conn()
-
-        if content is None:
-            logger.warning("Object not found: %s", object_path)
-            return None
-        try:
-            return json.loads(content)
-        except json.JSONDecodeError:
-            pass
-
-        try:
-            reader = csv.DictReader(StringIO(content))
-            rows = list(reader)
-            if rows:
-                return rows
-        except Exception:
-            pass
-        return content
-
-    except minio.error.S3Error as e:
-        if e.code == "NoSuchKey":
-            logger.warning("Object not found: %s", object_path)
-            return None
         raise
 
 

--- a/src/five_safes_tes_workbench/helpers/minio.py
+++ b/src/five_safes_tes_workbench/helpers/minio.py
@@ -1,13 +1,39 @@
 import csv
+from dataclasses import dataclass
 import json
 from typing import Any
 from io import StringIO
 from minio import Minio
 import minio
+import requests
+import xml.etree.ElementTree as ET
+
+from ..constants.minio import (
+    STS_DURATION_SECONDS,
+    STS_NAMESPACE,
+    STS_TOKEN_EXCHANGE_TIMEOUT,
+)
 from ..schema.config_schema import ConfigValidationModel
 from ..utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+@dataclass
+class MinioCredentials:
+    """
+    MinIO credentials type.
+
+    Attributes:
+    -----------
+    - access_key: The access key for the MinIO client.
+    - secret_key: The secret key for the MinIO client.
+    - session_token: The session token for the MinIO client.
+    """
+
+    access_key: str
+    secret_key: str
+    session_token: str
 
 
 def list_results(
@@ -104,3 +130,62 @@ def get_and_parse_result(
             logger.warning("Object not found: %s", object_path)
             return None
         raise
+
+
+def _parse_sts_response(response: requests.Response) -> MinioCredentials:
+    """
+    Parse and validate the STS response and return the credentials.
+
+    Parameters
+    ----------
+    - response: The response from the STS endpoint.
+
+    Returns
+    -------
+    A MinioCredentials object.
+    """
+    root = ET.fromstring(response.text)
+    credentials = root.find(".//sts:Credentials", STS_NAMESPACE)
+
+    if credentials is None:
+        raise RuntimeError("STS response contained no Credentials element")
+
+    access_key = credentials.findtext("sts:AccessKeyId", namespaces=STS_NAMESPACE)
+    secret_key = credentials.findtext("sts:SecretAccessKey", namespaces=STS_NAMESPACE)
+    session_token = credentials.findtext("sts:SessionToken", namespaces=STS_NAMESPACE)
+
+    if access_key is None or secret_key is None or session_token is None:
+        raise RuntimeError("STS response did not contain all required credentials")
+
+    return MinioCredentials(
+        access_key=access_key, secret_key=secret_key, session_token=session_token
+    )
+
+
+def exchange_minio_token(bearer: str, sts_endpoint: str) -> MinioCredentials:
+    """
+    Call the STS AssumeRoleWithWebIdentity action and return temporary
+    AWS-style credentials.
+    """
+    logger.info(
+        "Exchanging bearer token for MinIO credentials via STS (%s)", sts_endpoint
+    )
+
+    response = requests.post(
+        sts_endpoint,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data={
+            "Action": "AssumeRoleWithWebIdentity",
+            "Version": "2011-06-15",
+            "DurationSeconds": STS_DURATION_SECONDS,
+            "WebIdentityToken": bearer,
+        },
+        timeout=STS_TOKEN_EXCHANGE_TIMEOUT,
+    )
+
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"STS token exchange failed ({response.status_code}): {response.text}"
+        )
+
+    return _parse_sts_response(response)

--- a/src/five_safes_tes_workbench/helpers/url.py
+++ b/src/five_safes_tes_workbench/helpers/url.py
@@ -10,6 +10,8 @@ def is_https(url: str) -> bool:
     - url: The URL to check.
 
     Returns:
+    --------
+    True if HTTPS, False if HTTP.
     """
     parsed = urlparse(url)
     if parsed.scheme == "https":
@@ -17,3 +19,27 @@ def is_https(url: str) -> bool:
     if parsed.scheme == "http":
         return False
     raise ValueError(f"URL must start with http:// or https://, got: {url}")
+
+
+def strip_scheme(url: str) -> str:
+    """
+    Remove the ``http://`` or ``https://`` scheme from a URL, returning
+    only the ``host:port`` (and any path) portion.
+
+    The MinIO Python client constructor does not accept a scheme prefix;
+    this helper normalises user-supplied endpoints so both
+    ``"localhost:9000"`` and ``"http://localhost:9000"`` are accepted.
+
+    Parameters:
+    -----------
+    - url: URL with or without a scheme prefix.
+
+    Returns:
+    --------
+    The URL with the scheme stripped (e.g. ``"localhost:9000"``).
+    """
+    parsed = urlparse(url)
+    if parsed.scheme in ("http", "https"):
+        # netloc contains host:port; path covers anything after
+        return parsed.netloc + parsed.path.rstrip("/")
+    return url

--- a/src/five_safes_tes_workbench/helpers/url.py
+++ b/src/five_safes_tes_workbench/helpers/url.py
@@ -1,0 +1,19 @@
+from urllib.parse import urlparse
+
+
+def is_https(url: str) -> bool:
+    """
+    Check if a URL is HTTPS.
+
+    Parameters:
+    -----------
+    - url: The URL to check.
+
+    Returns:
+    """
+    parsed = urlparse(url)
+    if parsed.scheme == "https":
+        return True
+    if parsed.scheme == "http":
+        return False
+    raise ValueError(f"URL must start with http:// or https://, got: {url}")

--- a/src/five_safes_tes_workbench/notebooks/workbench-example.ipynb
+++ b/src/five_safes_tes_workbench/notebooks/workbench-example.ipynb
@@ -11,16 +11,8 @@
         "\n",
         "from five_safes_tes_workbench.workbench import Workbench\n",
         "\n",
-        "wb = Workbench()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "a0708852",
-      "metadata": {},
-      "outputs": [],
-      "source": [
+        "wb = Workbench()\n",
+        "\n",
         "wb.validate(\n",
         "    project=\"Testing\",\n",
         "    tes_base_url=\"http://localhost:5034\",\n",

--- a/src/five_safes_tes_workbench/notebooks/workbench-example.ipynb
+++ b/src/five_safes_tes_workbench/notebooks/workbench-example.ipynb
@@ -2,7 +2,7 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "id": "4039a22f",
       "metadata": {},
       "outputs": [],
@@ -16,59 +16,114 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "baeddd58",
+      "execution_count": 2,
+      "id": "a0708852",
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "INFO | Validation successful\n",
+            "INFO | Config: project='Testing' tes_base_url='http://localhost:5034/' minio_sts_endpoint='http://localhost:9000/sts' minio_endpoint='localhost:9000' minio_output_bucket='11343output' tres=['DEMO']\n",
+            "INFO | Auth mode: AuthMode.CREDENTIALS\n",
+            "INFO | Auth: auth_mode=<AuthMode.CREDENTIALS: 'credentials'> access_token=None client_id='Dare-Control-API' client_secret='2e60b956-16bc-4dea-8b49-118a8baac5e5' keycloak_url='http://localhost:8085/' username='globaladminuser' password='password123'\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "<five_safes_tes_workbench.workbench.Workbench at 0x115fb4d70>"
+            ]
+          },
+          "execution_count": 2,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
-        "# Adding Configuration using direct parameters (Config & Auth)\n",
-        "\n",
         "wb.validate(\n",
         "    project=\"Testing\",\n",
         "    tes_base_url=\"http://localhost:5034\",\n",
-        "    minio_sts_endpoint=\"http://your-minio-endpoint:9000/sts\",\n",
-        "    minio_endpoint=\"your-minio-endpoint:9000\",\n",
-        "    minio_output_bucket=\"your-output-bucket-name\",\n",
+        "    minio_sts_endpoint=\"http://localhost:9000/sts\",\n",
+        "    minio_endpoint=\"localhost:9000\",\n",
+        "    minio_output_bucket=\"11343output\",\n",
         "    tres=[\"DEMO\"],\n",
         "    client_id=\"Dare-Control-API\",\n",
         "    client_secret=\"2e60b956-16bc-4dea-8b49-118a8baac5e5\",\n",
         "    username=\"globaladminuser\",\n",
         "    password=\"password123\",\n",
         "    keycloak_url=\"http://localhost:8085/\",\n",
-        ")\n",
-        "\n",
-        "wb.build_tes(\n",
-        "    name=\"Hello World\",\n",
-        "    image=\"alpine\",\n",
-        "    command=[\"echo\", \"hello\"],\n",
-        ")\n",
-        "\n",
-        "wb.submit()"
+        ")"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 3,
       "id": "28c2adb1",
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "INFO | TES Task built successfully\n",
+            "INFO | TES payload:\n",
+            "{\n",
+            "   \"name\": \"basic-sqlpg-tre\",\n",
+            "   \"description\": \"Basic SQLPG TRE\",\n",
+            "   \"inputs\": [],\n",
+            "   \"outputs\": [\n",
+            "      {\n",
+            "         \"url\": \"s3://\",\n",
+            "         \"path\": \"/outputs\",\n",
+            "         \"type\": \"DIRECTORY\",\n",
+            "         \"name\": \"Stdout\",\n",
+            "         \"description\": \"Stdout results\"\n",
+            "      }\n",
+            "   ],\n",
+            "   \"executors\": [\n",
+            "      {\n",
+            "         \"image\": \"harbor.federated-analytics.ac.uk/5s-tes-analysis-tools/5s-tes-analysis-tools-tre-sqlpg:1.0.0\",\n",
+            "         \"command\": [\n",
+            "            \"--Output=/outputs/output.csv\",\n",
+            "            \"--Query=WITH user_query AS (SELECT value_as_number FROM public.measurement \\n            WHERE measurement_concept_id = 3000905 AND value_as_number IS NOT NULL) \\n            SELECT COUNT(*) AS n, SUM(value_as_number) AS total FROM user_query;\"\n",
+            "         ]\n",
+            "      }\n",
+            "   ],\n",
+            "   \"tags\": {\n",
+            "      \"project\": \"Testing\",\n",
+            "      \"tres\": \"DEMO\"\n",
+            "   },\n",
+            "   \"creation_time\": \"2026-04-23T16:12:35.695972+00:00\"\n",
+            "}\n",
+            "INFO | Fetching token from keycloak...\n",
+            "INFO | Requesting keycloak token from http://localhost:8085/realms/Dare-Control/protocol/openid-connect/token\n",
+            "INFO | Keycloak token fetched successfully\n",
+            "INFO | Submitting task to http://localhost:5034/v1/tasks\n",
+            "INFO | Task submitted successfully! ID: 117\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "'117'"
+            ]
+          },
+          "execution_count": 3,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
-        "# Adding Configuration using direct parameters (Config & Auth - Access Token)\n",
-        "\n",
-        "wb.validate(\n",
-        "    project=\"Testing\",\n",
-        "    tes_base_url=\"http://localhost:5034\",\n",
-        "    minio_sts_endpoint=\"http://your-minio-endpoint:9000/sts\",\n",
-        "    minio_endpoint=\"your-minio-endpoint:9000\",\n",
-        "    minio_output_bucket=\"your-output-bucket-name\",\n",
-        "    tres=[\"DEMO\"],\n",
-        "    access_token=\"your-access-token\"\n",
-        ")\n",
-        "\n",
         "wb.build_tes(\n",
-        "    name=\"Hello World\",\n",
-        "    image=\"alpine\",\n",
-        "    command=[\"echo\", \"hello\"],\n",
+        "    name=\"basic-sqlpg-tre\",\n",
+        "    description=\"Basic SQLPG TRE\",\n",
+        "    image=\"harbor.federated-analytics.ac.uk/5s-tes-analysis-tools/5s-tes-analysis-tools-tre-sqlpg:1.0.0\",\n",
+        "    command=[\"--Output=/outputs/output.csv\",\n",
+        "            \"\"\"--Query=WITH user_query AS (SELECT value_as_number FROM public.measurement \n",
+        "            WHERE measurement_concept_id = 3000905 AND value_as_number IS NOT NULL) \n",
+        "            SELECT COUNT(*) AS n, SUM(value_as_number) AS total FROM user_query;\"\"\"],\n",
         ")\n",
         "\n",
         "wb.submit()\n"
@@ -76,28 +131,42 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "c672d730",
+      "execution_count": 7,
+      "id": "ba39be40",
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "INFO | Fetching token from keycloak...\n",
+            "INFO | Requesting keycloak token from http://localhost:8085/realms/Dare-Control/protocol/openid-connect/token\n",
+            "INFO | Keycloak token fetched successfully\n",
+            "INFO | Exchanging bearer token for MinIO credentials via STS (http://localhost:9000/sts)\n",
+            "INFO | MinIO client initialised (endpoint=localhost:9000, secure=False)\n",
+            "INFO | Child task ID: 118\n",
+            "INFO | Found 0 result object(s) for task 118\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "{}"
+            ]
+          },
+          "execution_count": 7,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
-        "# Adding Configuration using config file (YAML Config File)\n",
-        "\n",
-        "wb.validate(config_path=\"../../../testconfig.yml\") #type: ignore\n",
-        "\n",
-        "wb.build_tes(\n",
-        "    name=\"Hello World\",\n",
-        "    image=\"alpine\",\n",
-        "    command=[\"echo\", \"hello\"],\n",
-        ")\n",
-        "\n",
-        "wb.submit()"
+        "wb.fetch_results(tre=\"DEMO\")"
       ]
     }
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": "workbench",
+      "display_name": ".venv",
       "language": "python",
       "name": "python3"
     },
@@ -111,7 +180,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.13.11"
+      "version": "3.13.7"
     }
   },
   "nbformat": 4,

--- a/src/five_safes_tes_workbench/notebooks/workbench-example.ipynb
+++ b/src/five_safes_tes_workbench/notebooks/workbench-example.ipynb
@@ -2,7 +2,7 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "id": "4039a22f",
       "metadata": {},
       "outputs": [],
@@ -16,31 +16,10 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "id": "a0708852",
       "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "INFO | Validation successful\n",
-            "INFO | Config: project='Testing' tes_base_url='http://localhost:5034/' minio_sts_endpoint='http://localhost:9000/sts' minio_endpoint='localhost:9000' minio_output_bucket='11343output' tres=['DEMO']\n",
-            "INFO | Auth mode: AuthMode.CREDENTIALS\n",
-            "INFO | Auth: auth_mode=<AuthMode.CREDENTIALS: 'credentials'> access_token=None client_id='Dare-Control-API' client_secret='2e60b956-16bc-4dea-8b49-118a8baac5e5' keycloak_url='http://localhost:8085/' username='globaladminuser' password='password123'\n"
-          ]
-        },
-        {
-          "data": {
-            "text/plain": [
-              "<five_safes_tes_workbench.workbench.Workbench at 0x115fb4d70>"
-            ]
-          },
-          "execution_count": 2,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "wb.validate(\n",
         "    project=\"Testing\",\n",
@@ -59,62 +38,10 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": null,
       "id": "28c2adb1",
       "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "INFO | TES Task built successfully\n",
-            "INFO | TES payload:\n",
-            "{\n",
-            "   \"name\": \"basic-sqlpg-tre\",\n",
-            "   \"description\": \"Basic SQLPG TRE\",\n",
-            "   \"inputs\": [],\n",
-            "   \"outputs\": [\n",
-            "      {\n",
-            "         \"url\": \"s3://\",\n",
-            "         \"path\": \"/outputs\",\n",
-            "         \"type\": \"DIRECTORY\",\n",
-            "         \"name\": \"Stdout\",\n",
-            "         \"description\": \"Stdout results\"\n",
-            "      }\n",
-            "   ],\n",
-            "   \"executors\": [\n",
-            "      {\n",
-            "         \"image\": \"harbor.federated-analytics.ac.uk/5s-tes-analysis-tools/5s-tes-analysis-tools-tre-sqlpg:1.0.0\",\n",
-            "         \"command\": [\n",
-            "            \"--Output=/outputs/output.csv\",\n",
-            "            \"--Query=WITH user_query AS (SELECT value_as_number FROM public.measurement \\n            WHERE measurement_concept_id = 3000905 AND value_as_number IS NOT NULL) \\n            SELECT COUNT(*) AS n, SUM(value_as_number) AS total FROM user_query;\"\n",
-            "         ]\n",
-            "      }\n",
-            "   ],\n",
-            "   \"tags\": {\n",
-            "      \"project\": \"Testing\",\n",
-            "      \"tres\": \"DEMO\"\n",
-            "   },\n",
-            "   \"creation_time\": \"2026-04-23T16:12:35.695972+00:00\"\n",
-            "}\n",
-            "INFO | Fetching token from keycloak...\n",
-            "INFO | Requesting keycloak token from http://localhost:8085/realms/Dare-Control/protocol/openid-connect/token\n",
-            "INFO | Keycloak token fetched successfully\n",
-            "INFO | Submitting task to http://localhost:5034/v1/tasks\n",
-            "INFO | Task submitted successfully! ID: 117\n"
-          ]
-        },
-        {
-          "data": {
-            "text/plain": [
-              "'117'"
-            ]
-          },
-          "execution_count": 3,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "wb.build_tes(\n",
         "    name=\"basic-sqlpg-tre\",\n",
@@ -131,36 +58,22 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": null,
+      "id": "1b6ec5c7",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "wb.fetch_all_results()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
       "id": "ba39be40",
       "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "INFO | Fetching token from keycloak...\n",
-            "INFO | Requesting keycloak token from http://localhost:8085/realms/Dare-Control/protocol/openid-connect/token\n",
-            "INFO | Keycloak token fetched successfully\n",
-            "INFO | Exchanging bearer token for MinIO credentials via STS (http://localhost:9000/sts)\n",
-            "INFO | MinIO client initialised (endpoint=localhost:9000, secure=False)\n",
-            "INFO | Child task ID: 118\n",
-            "INFO | Found 0 result object(s) for task 118\n"
-          ]
-        },
-        {
-          "data": {
-            "text/plain": [
-              "{}"
-            ]
-          },
-          "execution_count": 7,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
-        "wb.fetch_results(tre=\"DEMO\")"
+        "wb.fetch_result_by_tre(tre=\"DEMO\")"
       ]
     }
   ],

--- a/src/five_safes_tes_workbench/schema/config_schema.py
+++ b/src/five_safes_tes_workbench/schema/config_schema.py
@@ -1,9 +1,16 @@
 from typing import Annotated
-from pydantic import BaseModel, field_validator, ValidationInfo, AnyHttpUrl, BeforeValidator
+from pydantic import (
+    BaseModel,
+    field_validator,
+    ValidationInfo,
+    AnyHttpUrl,
+    BeforeValidator,
+)
 from ..common.validator_enums import ConfigKey
 
 
 HttpUrlString = Annotated[str, BeforeValidator(lambda v: str(AnyHttpUrl(v)))]
+
 
 class ConfigValidationModel(BaseModel):
     """
@@ -19,14 +26,15 @@ class ConfigValidationModel(BaseModel):
     - minio_output_bucket: The name of the MinIO bucket for output.
     - tres: A list of TREs.
     """
+
     model_config = {"frozen": True}
 
     project: str
     tes_base_url: HttpUrlString
     minio_sts_endpoint: HttpUrlString
-    minio_endpoint: str
+    minio_endpoint: HttpUrlString
     minio_output_bucket: str
-    tres: list[str] 
+    tres: list[str]
 
     @field_validator(
         ConfigKey.PROJECT.value,
@@ -34,14 +42,13 @@ class ConfigValidationModel(BaseModel):
         ConfigKey.MINIO_STS_ENDPOINT.value,
         ConfigKey.MINIO_ENDPOINT.value,
         ConfigKey.MINIO_OUTPUT_BUCKET.value,
-        mode="before"
+        mode="before",
     )
     @classmethod
     def check_not_empty(cls, v: str, info: ValidationInfo) -> str:
         if not v or not v.strip():
             raise ValueError(f"'{info.field_name}' must not be empty")
         return v.strip()
-    
 
     @field_validator(ConfigKey.TRES.value)
     @classmethod
@@ -51,10 +58,5 @@ class ConfigValidationModel(BaseModel):
         cleaned = [item.strip() for item in v]
         for i, item in enumerate(cleaned):
             if not item:
-                raise ValueError(
-                    f"'tres' contains an empty value at index {i}"
-                )
+                raise ValueError(f"'tres' contains an empty value at index {i}")
         return cleaned
-    
-
-

--- a/src/five_safes_tes_workbench/workbench.py
+++ b/src/five_safes_tes_workbench/workbench.py
@@ -32,7 +32,6 @@ class Workbench:
         self._validator = WorkbenchValidateBuilder()
         self._task_builder = WorkbenchTESBuilder()
         self._submitter = WorkbenchSubmitBuilder()
-        self._minio_client = MinioClientBuilder()
         self._last_task_id: str | None = None
 
     # ----- Validation Builder -----
@@ -133,16 +132,17 @@ class Workbench:
                 f"TRE {tre} not found in the configuration. Please specify a valid TRE."
             )
 
-        self._minio_client.initialise(
+        #  init Minio client on demand
+        minio_client = MinioClientBuilder(
             config=self._validator.config,
             auth=self._validator.auth,
         )
         child_task_info = get_child_task_info(self._validator.config, resolved_id, tre)
 
         check_status_message = check_child_task_status(child_task_info)
-        if check_status_message:
-            return check_status_message
-        return self._minio_client.fetch_result(child_task_info.id, bucket=bucket)
+        if check_status_message is not None:
+            raise ValueError(check_status_message)
+        return minio_client.fetch_result(child_task_info.id, bucket=bucket)
 
     def fetch_all_results(
         self,
@@ -178,7 +178,8 @@ class Workbench:
 
         results: dict[str, dict[str, Any]] = {}
 
-        self._minio_client.initialise(
+        #  init Minio client on demand
+        minio_client = MinioClientBuilder(
             config=self._validator.config,
             auth=self._validator.auth,
         )
@@ -187,10 +188,8 @@ class Workbench:
                 self._validator.config, resolved_id, tre
             )
             check_status_message = check_child_task_status(child_task_info)
-            if check_status_message:
-                return check_status_message
-            results[tre] = self._minio_client.fetch_result(
-                child_task_info.id, bucket=bucket
-            )
+            if check_status_message is not None:
+                raise ValueError(check_status_message)
+            results[tre] = minio_client.fetch_result(child_task_info.id, bucket=bucket)
 
         return results

--- a/src/five_safes_tes_workbench/workbench.py
+++ b/src/five_safes_tes_workbench/workbench.py
@@ -1,8 +1,9 @@
-from typing import Unpack
+from typing import Any, Unpack
 
 from .core.validate_builder import WorkbenchValidateBuilder
 from .core.tes_builder import WorkbenchTESBuilder
 from .core.submit_builder import WorkbenchSubmitBuilder
+from .core.minio_builder import WorkbenchMinioBuilder
 from .common.validate_params import ConfigValidationParams
 from .common.tes_builder_params import TESTaskParams
 
@@ -15,19 +16,23 @@ class Workbench:
     -------
     This class holds the main methods as follows:
 
-    1. validate: Validates the configuration.
-    2. build_tes: Builds the TES task.
-    3. submit: Submits the TES task to the endpoint.
+    1. validate: Validates the configuration and authentication.
+    2. build_tes: Builds the TES task payload.
+    3. submit: Submits the TES task to the endpoint and stores the task ID.
+    4. fetch_results: Fetches task output objects from MinIO after the task
+       has completed.
     """
 
     def __init__(self) -> None:
         """
-        Initializes the Workbench with instances of the
-        validate builder, TES builder, and submit builder.
+        Initializes the Workbench with instances of the validate builder,
+        TES builder, submit builder, and MinIO builder.
         """
         self._validator = WorkbenchValidateBuilder()
         self._task_builder = WorkbenchTESBuilder()
         self._submitter = WorkbenchSubmitBuilder()
+        self._minio_builder = WorkbenchMinioBuilder()
+        self._last_task_id: str | None = None
 
     # ----- Validation Builder -----
 
@@ -37,8 +42,7 @@ class Workbench:
         **kwargs: Unpack[ConfigValidationParams],
     ) -> "Workbench":
         """
-        Validates the configuration and
-        authentication parameters.
+        Validates the configuration and authentication parameters.
 
         Parameters
         ----------
@@ -47,14 +51,13 @@ class Workbench:
         """
         self._validator.validate(config_path, **kwargs)
         return self
-    
+
     # ----- TES Builder -----
 
     def build_tes(self, **kwargs: Unpack[TESTaskParams]) -> "Workbench":
-        """ 
-        Builds the TES message and provided TES 
-        task parameters.
-        
+        """
+        Builds the TES message from the provided TES task parameters.
+
         Parameters
         ----------
         - kwargs: Parameters for building the TES task.
@@ -68,12 +71,58 @@ class Workbench:
     # ----- Submit Builder -----
 
     def submit(self) -> str:
-        """ 
-        Submits the built TES task to the 
-        configured TES endpoint.
         """
-        return self._submitter.submit(
+        Submits the built TES task to the configured TES endpoint.
+
+        Returns
+        -------
+        The ID of the submitted task. The ID is also stored internally so
+        that a subsequent :meth:`fetch_results` call can use it without
+        requiring it to be passed explicitly.
+        """
+        task_id = self._submitter.submit(
             config=self._validator.config,
             auth=self._validator.auth,
             task=self._task_builder.tes_task,
         )
+        self._last_task_id = task_id
+        return task_id
+
+    # ----- MinIO Results Builder -----
+
+    def fetch_results(
+        self,
+        task_id: str | None = None,
+        bucket: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Fetch all output objects written by a completed TES task from MinIO.
+
+        Authentication is re-used from the earlier :meth:`validate` call.
+        Credentials are exchanged at the configured STS endpoint so that a
+        temporary MinIO session is obtained automatically.
+
+        Parameters
+        ----------
+        - task_id: ID of the task whose results to retrieve. Defaults to
+          the ID returned by the most recent :meth:`submit` call.
+        - bucket: Override the output bucket from config. Defaults to
+          ``config.minio_output_bucket``.
+
+        Returns
+        -------
+        A dict mapping each result object path to its parsed content
+        (JSON / CSV decoded where possible, raw string otherwise).
+        """
+        resolved_id = task_id or self._last_task_id
+        if resolved_id is None:
+            raise ValueError(
+                "No task ID available. Either call submit() first or pass "
+                "a task_id explicitly to fetch_results()."
+            )
+
+        self._minio_builder.initialise(
+            config=self._validator.config,
+            auth=self._validator.auth,
+        )
+        return self._minio_builder.fetch_all_results(resolved_id, bucket=bucket)

--- a/src/five_safes_tes_workbench/workbench.py
+++ b/src/five_safes_tes_workbench/workbench.py
@@ -91,7 +91,7 @@ class Workbench:
 
     # ----- MinIO Results Commands -----
 
-    def fetch_result_by_tre(
+    def fetch_results_by_tre(
         self,
         task_id: str | None = None,
         tre: str | None = None,
@@ -212,13 +212,13 @@ class Workbench:
             check_status_message = check_child_task_status(child_task_info)
             if check_status_message is not None:
                 raise ValueError(check_status_message)
-            base_dir = (
+            resolved_output_dir = (
                 Path(output_dir)
                 if output_dir is not None
                 else Path.cwd() / "output" / tre / str(child_task_info.id)
             )
             results[tre] = minio_client.download_results(
-                child_task_info.id, base_dir, bucket=bucket
+                child_task_info.id, resolved_output_dir, bucket=bucket
             )
 
         return results

--- a/src/five_safes_tes_workbench/workbench.py
+++ b/src/five_safes_tes_workbench/workbench.py
@@ -1,4 +1,5 @@
-from typing import Any, Unpack
+from pathlib import Path
+from typing import Unpack
 
 from .core.validate_builder import WorkbenchValidateBuilder
 from .core.tes_builder import WorkbenchTESBuilder
@@ -95,9 +96,14 @@ class Workbench:
         task_id: str | None = None,
         tre: str | None = None,
         bucket: str | None = None,
-    ) -> dict[str, Any]:
+        output_dir: Path | str | None = None,
+    ) -> list[Path]:
         """
-        Fetch all output objects written by a completed TES task from MinIO.
+        Download all output objects for a completed TES task from MinIO to disk.
+
+        Files are saved under ``<output_dir>/<filename>`` where
+        ``output_dir`` defaults to an ``output/`` folder created next to
+        the calling notebook (i.e. ``Path.cwd() / "output"``).
 
         Authentication is re-used from the earlier :meth:`validate` call.
         Credentials are exchanged at the configured STS endpoint so that a
@@ -107,20 +113,21 @@ class Workbench:
         ----------
         - task_id: ID of the task whose results to retrieve. Defaults to
           the ID returned by the most recent :meth:`submit` call.
-        - tre: Name of the TRE to fetch the results for.
+        - tre: Name of the TRE to download the results for.
         - bucket: Override the output bucket from config. Defaults to
           ``config.minio_output_bucket``.
+        - output_dir: Directory to write downloaded files into. Defaults
+          to ``Path.cwd() / "output" / <tre>``.
 
         Returns
         -------
-        A dict mapping each result object path to its parsed content
-        (JSON / CSV decoded where possible, raw string otherwise).
+        List of :class:`~pathlib.Path` objects for every downloaded file.
         """
         resolved_id = task_id or self._last_task_id
         if resolved_id is None:
             raise ValueError(
                 "No Submission task ID available. Either call submit() first or pass "
-                "a task_id explicitly to fetch_results()."
+                "a task_id explicitly to fetch_result_by_tre()."
             )
 
         if tre is None:
@@ -132,7 +139,10 @@ class Workbench:
                 f"TRE {tre} not found in the configuration. Please specify a valid TRE."
             )
 
-        #  init Minio client on demand
+        resolved_output_dir = (
+            Path(output_dir) if output_dir is not None else Path.cwd() / "output" / tre
+        )
+
         minio_client = MinioClientBuilder(
             config=self._validator.config,
             auth=self._validator.auth,
@@ -142,15 +152,24 @@ class Workbench:
         check_status_message = check_child_task_status(child_task_info)
         if check_status_message is not None:
             raise ValueError(check_status_message)
-        return minio_client.fetch_result(child_task_info.id, bucket=bucket)
+
+        return minio_client.download_results(
+            child_task_info.id, resolved_output_dir, bucket=bucket
+        )
 
     def fetch_all_results(
         self,
         task_id: str | None = None,
         bucket: str | None = None,
-    ) -> dict[str, Any]:
+        output_dir: Path | str | None = None,
+    ) -> dict[str, list[Path]]:
         """
-        Fetch all output objects written by a completed TES task from MinIO.
+        Download all output objects for a completed TES task from MinIO to disk
+        for every configured TRE.
+
+        Files are saved under ``<output_dir>/<tre>/<filename>`` where
+        ``output_dir`` defaults to an ``output/`` folder created next to
+        the calling notebook (i.e. ``Path.cwd() / "output"``).
 
         Authentication is re-used from the earlier :meth:`validate` call.
         Credentials are exchanged at the configured STS endpoint so that a
@@ -160,25 +179,30 @@ class Workbench:
         ----------
         - task_id: ID of the task whose results to retrieve. Defaults to
           the ID returned by the most recent :meth:`submit` call.
-        - tre: Name of the TRE to fetch the results for.
         - bucket: Override the output bucket from config. Defaults to
           ``config.minio_output_bucket``.
+        - output_dir: Root directory for downloads. Each TRE gets its own
+          sub-folder ``<output_dir>/<tre>/``. Defaults to
+          ``Path.cwd() / "output"``.
 
         Returns
         -------
-        A dict mapping each result object path to its parsed content
-        (JSON / CSV decoded where possible, raw string otherwise).
+        Dict mapping each TRE name to the list of
+        :class:`~pathlib.Path` objects for its downloaded files.
         """
         resolved_id = task_id or self._last_task_id
         if resolved_id is None:
             raise ValueError(
                 "No Submission task ID available. Either call submit() first or pass "
-                "a task_id explicitly to fetch_results()."
+                "a task_id explicitly to fetch_all_results()."
             )
 
-        results: dict[str, dict[str, Any]] = {}
+        base_dir = (
+            Path(output_dir) if output_dir is not None else Path.cwd() / "output"
+        )
 
-        #  init Minio client on demand
+        results: dict[str, list[Path]] = {}
+
         minio_client = MinioClientBuilder(
             config=self._validator.config,
             auth=self._validator.auth,
@@ -190,6 +214,8 @@ class Workbench:
             check_status_message = check_child_task_status(child_task_info)
             if check_status_message is not None:
                 raise ValueError(check_status_message)
-            results[tre] = minio_client.fetch_result(child_task_info.id, bucket=bucket)
+            results[tre] = minio_client.download_results(
+                child_task_info.id, base_dir / tre, bucket=bucket
+            )
 
         return results

--- a/src/five_safes_tes_workbench/workbench.py
+++ b/src/five_safes_tes_workbench/workbench.py
@@ -5,7 +5,10 @@ from .core.validate_builder import WorkbenchValidateBuilder
 from .core.tes_builder import WorkbenchTESBuilder
 from .core.submit_builder import WorkbenchSubmitBuilder
 from .core.minio_client import MinioClientBuilder
-from .helpers.children_task import check_child_task_status, get_child_task_info
+from .helpers.children_task import (
+    get_child_task_info,
+    validate_child_task_status,
+)
 from .common.validate_params import ConfigValidationParams
 from .common.tes_builder_params import TESTaskParams
 
@@ -140,9 +143,7 @@ class Workbench:
             )
         child_task_info = get_child_task_info(self._validator.config, resolved_id, tre)
 
-        check_status_message = check_child_task_status(child_task_info)
-        if check_status_message is not None:
-            raise ValueError(check_status_message)
+        validate_child_task_status(child_task_info)
 
         resolved_output_dir = (
             Path(output_dir)
@@ -209,9 +210,8 @@ class Workbench:
             child_task_info = get_child_task_info(
                 self._validator.config, resolved_id, tre
             )
-            check_status_message = check_child_task_status(child_task_info)
-            if check_status_message is not None:
-                raise ValueError(check_status_message)
+            validate_child_task_status(child_task_info)
+
             resolved_output_dir = (
                 Path(output_dir)
                 if output_dir is not None

--- a/src/five_safes_tes_workbench/workbench.py
+++ b/src/five_safes_tes_workbench/workbench.py
@@ -3,7 +3,7 @@ from typing import Any, Unpack
 from .core.validate_builder import WorkbenchValidateBuilder
 from .core.tes_builder import WorkbenchTESBuilder
 from .core.submit_builder import WorkbenchSubmitBuilder
-from .core.minio_client import WorkbenchMinioClient
+from .core.minio_client import MinioClientBuilder
 from .helpers.minio import check_child_task_status, get_child_task_info
 from .common.validate_params import ConfigValidationParams
 from .common.tes_builder_params import TESTaskParams
@@ -32,7 +32,7 @@ class Workbench:
         self._validator = WorkbenchValidateBuilder()
         self._task_builder = WorkbenchTESBuilder()
         self._submitter = WorkbenchSubmitBuilder()
-        self._minio_client = WorkbenchMinioClient()
+        self._minio_client = MinioClientBuilder()
         self._last_task_id: str | None = None
 
     # ----- Validation Builder -----

--- a/src/five_safes_tes_workbench/workbench.py
+++ b/src/five_safes_tes_workbench/workbench.py
@@ -1,11 +1,10 @@
 from typing import Any, Unpack
 
-from five_safes_tes_workbench.helpers.minio import get_child_task_id
-
 from .core.validate_builder import WorkbenchValidateBuilder
 from .core.tes_builder import WorkbenchTESBuilder
 from .core.submit_builder import WorkbenchSubmitBuilder
 from .core.minio_client import WorkbenchMinioClient
+from .helpers.minio import check_child_task_status, get_child_task_info
 from .common.validate_params import ConfigValidationParams
 from .common.tes_builder_params import TESTaskParams
 
@@ -138,9 +137,12 @@ class Workbench:
             config=self._validator.config,
             auth=self._validator.auth,
         )
-        child_task_id = get_child_task_id(self._validator.config, resolved_id, tre)
+        child_task_info = get_child_task_info(self._validator.config, resolved_id, tre)
 
-        return self._minio_client.fetch_result(child_task_id, bucket=bucket)
+        check_status_message = check_child_task_status(child_task_info)
+        if check_status_message:
+            return check_status_message
+        return self._minio_client.fetch_result(child_task_info.id, bucket=bucket)
 
     def fetch_all_results(
         self,
@@ -181,7 +183,14 @@ class Workbench:
             auth=self._validator.auth,
         )
         for tre in self._validator.config.tres:
-            child_task_id = get_child_task_id(self._validator.config, resolved_id, tre)
-            results[tre] = self._minio_client.fetch_result(child_task_id, bucket=bucket)
+            child_task_info = get_child_task_info(
+                self._validator.config, resolved_id, tre
+            )
+            check_status_message = check_child_task_status(child_task_info)
+            if check_status_message:
+                return check_status_message
+            results[tre] = self._minio_client.fetch_result(
+                child_task_info.id, bucket=bucket
+            )
 
         return results

--- a/src/five_safes_tes_workbench/workbench.py
+++ b/src/five_safes_tes_workbench/workbench.py
@@ -3,7 +3,7 @@ from typing import Any, Unpack
 from .core.validate_builder import WorkbenchValidateBuilder
 from .core.tes_builder import WorkbenchTESBuilder
 from .core.submit_builder import WorkbenchSubmitBuilder
-from .core.minio_builder import WorkbenchMinioBuilder
+from .core.minio_client import WorkbenchMinioClient
 from .common.validate_params import ConfigValidationParams
 from .common.tes_builder_params import TESTaskParams
 
@@ -31,7 +31,7 @@ class Workbench:
         self._validator = WorkbenchValidateBuilder()
         self._task_builder = WorkbenchTESBuilder()
         self._submitter = WorkbenchSubmitBuilder()
-        self._minio_builder = WorkbenchMinioBuilder()
+        self._minio_client = WorkbenchMinioClient()
         self._last_task_id: str | None = None
 
     # ----- Validation Builder -----
@@ -88,7 +88,7 @@ class Workbench:
         self._last_task_id = task_id
         return task_id
 
-    # ----- MinIO Results Builder -----
+    # ----- MinIO Results Commands -----
 
     def fetch_result_by_tre(
         self,
@@ -132,13 +132,13 @@ class Workbench:
                 f"TRE {tre} not found in the configuration. Please specify a valid TRE."
             )
 
-        self._minio_builder.initialise(
+        self._minio_client.initialise(
             config=self._validator.config,
             auth=self._validator.auth,
         )
-        child_task_id = self._minio_builder.get_child_task_id(resolved_id, tre)
+        child_task_id = self._minio_client.get_child_task_id(resolved_id, tre)
 
-        return self._minio_builder.fetch_result(child_task_id, bucket=bucket)
+        return self._minio_client.fetch_result(child_task_id, bucket=bucket)
 
     def fetch_all_results(
         self,
@@ -174,14 +174,12 @@ class Workbench:
 
         results: dict[str, dict[str, Any]] = {}
 
-        self._minio_builder.initialise(
+        self._minio_client.initialise(
             config=self._validator.config,
             auth=self._validator.auth,
         )
         for tre in self._validator.config.tres:
-            child_task_id = self._minio_builder.get_child_task_id(resolved_id, tre)
-            results[tre] = self._minio_builder.fetch_result(
-                child_task_id, bucket=bucket
-            )
+            child_task_id = self._minio_client.get_child_task_id(resolved_id, tre)
+            results[tre] = self._minio_client.fetch_result(child_task_id, bucket=bucket)
 
         return results

--- a/src/five_safes_tes_workbench/workbench.py
+++ b/src/five_safes_tes_workbench/workbench.py
@@ -4,7 +4,7 @@ from .core.validate_builder import WorkbenchValidateBuilder
 from .core.tes_builder import WorkbenchTESBuilder
 from .core.submit_builder import WorkbenchSubmitBuilder
 from .core.minio_client import MinioClientBuilder
-from .helpers.minio import check_child_task_status, get_child_task_info
+from .helpers.children_task import check_child_task_status, get_child_task_info
 from .common.validate_params import ConfigValidationParams
 from .common.tes_builder_params import TESTaskParams
 

--- a/src/five_safes_tes_workbench/workbench.py
+++ b/src/five_safes_tes_workbench/workbench.py
@@ -90,7 +90,7 @@ class Workbench:
 
     # ----- MinIO Results Builder -----
 
-    def fetch_results(
+    def fetch_result_by_tre(
         self,
         task_id: str | None = None,
         tre: str | None = None,
@@ -138,4 +138,50 @@ class Workbench:
         )
         child_task_id = self._minio_builder.get_child_task_id(resolved_id, tre)
 
-        return self._minio_builder.fetch_all_results(child_task_id, bucket=bucket)
+        return self._minio_builder.fetch_result(child_task_id, bucket=bucket)
+
+    def fetch_all_results(
+        self,
+        task_id: str | None = None,
+        bucket: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Fetch all output objects written by a completed TES task from MinIO.
+
+        Authentication is re-used from the earlier :meth:`validate` call.
+        Credentials are exchanged at the configured STS endpoint so that a
+        temporary MinIO session is obtained automatically.
+
+        Parameters
+        ----------
+        - task_id: ID of the task whose results to retrieve. Defaults to
+          the ID returned by the most recent :meth:`submit` call.
+        - tre: Name of the TRE to fetch the results for.
+        - bucket: Override the output bucket from config. Defaults to
+          ``config.minio_output_bucket``.
+
+        Returns
+        -------
+        A dict mapping each result object path to its parsed content
+        (JSON / CSV decoded where possible, raw string otherwise).
+        """
+        resolved_id = task_id or self._last_task_id
+        if resolved_id is None:
+            raise ValueError(
+                "No Submission task ID available. Either call submit() first or pass "
+                "a task_id explicitly to fetch_results()."
+            )
+
+        results: dict[str, dict[str, Any]] = {}
+
+        self._minio_builder.initialise(
+            config=self._validator.config,
+            auth=self._validator.auth,
+        )
+        for tre in self._validator.config.tres:
+            child_task_id = self._minio_builder.get_child_task_id(resolved_id, tre)
+            results[tre] = self._minio_builder.fetch_result(
+                child_task_id, bucket=bucket
+            )
+
+        return results

--- a/src/five_safes_tes_workbench/workbench.py
+++ b/src/five_safes_tes_workbench/workbench.py
@@ -93,6 +93,7 @@ class Workbench:
     def fetch_results(
         self,
         task_id: str | None = None,
+        tre: str | None = None,
         bucket: str | None = None,
     ) -> dict[str, Any]:
         """
@@ -106,6 +107,7 @@ class Workbench:
         ----------
         - task_id: ID of the task whose results to retrieve. Defaults to
           the ID returned by the most recent :meth:`submit` call.
+        - tre: Name of the TRE to fetch the results for.
         - bucket: Override the output bucket from config. Defaults to
           ``config.minio_output_bucket``.
 
@@ -117,12 +119,23 @@ class Workbench:
         resolved_id = task_id or self._last_task_id
         if resolved_id is None:
             raise ValueError(
-                "No task ID available. Either call submit() first or pass "
+                "No Submission task ID available. Either call submit() first or pass "
                 "a task_id explicitly to fetch_results()."
+            )
+
+        if tre is None:
+            raise ValueError(
+                "No TRE available. Please specify the TRE to fetch the results for."
+            )
+        if tre not in self._validator.config.tres:
+            raise ValueError(
+                f"TRE {tre} not found in the configuration. Please specify a valid TRE."
             )
 
         self._minio_builder.initialise(
             config=self._validator.config,
             auth=self._validator.auth,
         )
-        return self._minio_builder.fetch_all_results(resolved_id, bucket=bucket)
+        child_task_id = self._minio_builder.get_child_task_id(resolved_id, tre)
+
+        return self._minio_builder.fetch_all_results(child_task_id, bucket=bucket)

--- a/src/five_safes_tes_workbench/workbench.py
+++ b/src/five_safes_tes_workbench/workbench.py
@@ -138,20 +138,22 @@ class Workbench:
             raise ValueError(
                 f"TRE {tre} not found in the configuration. Please specify a valid TRE."
             )
+        child_task_info = get_child_task_info(self._validator.config, resolved_id, tre)
+
+        check_status_message = check_child_task_status(child_task_info)
+        if check_status_message is not None:
+            raise ValueError(check_status_message)
 
         resolved_output_dir = (
-            Path(output_dir) if output_dir is not None else Path.cwd() / "output" / tre
+            Path(output_dir)
+            if output_dir is not None
+            else Path.cwd() / "output" / tre / str(child_task_info.id)
         )
 
         minio_client = MinioClientBuilder(
             config=self._validator.config,
             auth=self._validator.auth,
         )
-        child_task_info = get_child_task_info(self._validator.config, resolved_id, tre)
-
-        check_status_message = check_child_task_status(child_task_info)
-        if check_status_message is not None:
-            raise ValueError(check_status_message)
 
         return minio_client.download_results(
             child_task_info.id, resolved_output_dir, bucket=bucket
@@ -197,10 +199,6 @@ class Workbench:
                 "a task_id explicitly to fetch_all_results()."
             )
 
-        base_dir = (
-            Path(output_dir) if output_dir is not None else Path.cwd() / "output"
-        )
-
         results: dict[str, list[Path]] = {}
 
         minio_client = MinioClientBuilder(
@@ -214,8 +212,13 @@ class Workbench:
             check_status_message = check_child_task_status(child_task_info)
             if check_status_message is not None:
                 raise ValueError(check_status_message)
+            base_dir = (
+                Path(output_dir)
+                if output_dir is not None
+                else Path.cwd() / "output" / tre / str(child_task_info.id)
+            )
             results[tre] = minio_client.download_results(
-                child_task_info.id, base_dir / tre, bucket=bucket
+                child_task_info.id, base_dir, bucket=bucket
             )
 
         return results

--- a/src/five_safes_tes_workbench/workbench.py
+++ b/src/five_safes_tes_workbench/workbench.py
@@ -1,5 +1,7 @@
 from typing import Any, Unpack
 
+from five_safes_tes_workbench.helpers.minio import get_child_task_id
+
 from .core.validate_builder import WorkbenchValidateBuilder
 from .core.tes_builder import WorkbenchTESBuilder
 from .core.submit_builder import WorkbenchSubmitBuilder
@@ -136,7 +138,7 @@ class Workbench:
             config=self._validator.config,
             auth=self._validator.auth,
         )
-        child_task_id = self._minio_client.get_child_task_id(resolved_id, tre)
+        child_task_id = get_child_task_id(self._validator.config, resolved_id, tre)
 
         return self._minio_client.fetch_result(child_task_id, bucket=bucket)
 
@@ -179,7 +181,7 @@ class Workbench:
             auth=self._validator.auth,
         )
         for tre in self._validator.config.tres:
-            child_task_id = self._minio_client.get_child_task_id(resolved_id, tre)
+            child_task_id = get_child_task_id(self._validator.config, resolved_id, tre)
             results[tre] = self._minio_client.fetch_result(child_task_id, bucket=bucket)
 
         return results

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,8 @@ revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version < '3.14'",
 ]
 
 [[package]]
@@ -22,6 +23,49 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
 ]
 
 [[package]]
@@ -49,6 +93,51 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -131,6 +220,7 @@ name = "five-safes-tes-workbench"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "minio" },
     { name = "py-tes" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -145,6 +235,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "minio", specifier = ">=7.2.20" },
     { name = "py-tes", specifier = ">=1.1.2" },
     { name = "pydantic", specifier = ">=2.13.1" },
     { name = "pyyaml", specifier = ">=6.0.3" },
@@ -287,6 +378,22 @@ wheels = [
 ]
 
 [[package]]
+name = "minio"
+version = "7.2.20"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi" },
+    { name = "certifi" },
+    { name = "pycryptodome" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/df/6dfc6540f96a74125a11653cce717603fd5b7d0001a8e847b3e54e72d238/minio-7.2.20.tar.gz", hash = "sha256:95898b7a023fbbfde375985aa77e2cd6a0762268db79cf886f002a9ea8e68598", size = 136113, upload-time = "2025-11-27T00:37:15.569Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/9a/b697530a882588a84db616580f2ba5d1d515c815e11c30d219145afeec87/minio-7.2.20-py3-none-any.whl", hash = "sha256:eb33dd2fb80e04c3726a76b13241c6be3c4c46f8d81e1d58e757786f6501897e", size = 93751, upload-time = "2025-11-27T00:37:13.993Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "1.20.2"
 source = { registry = "https://pypi.org/simple" }
@@ -362,6 +469,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4a/51/9c3dfaa218ac8d824864a59ffffcd60903056f50339797a6cecdde813607/py_tes-1.1.2.tar.gz", hash = "sha256:2168d0c71061ad52c00cf42368f7e57341966587f8ac0ca147b9c0cb75bc858d", size = 16328, upload-time = "2025-04-09T03:31:17.593Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/74/24/1f504b4e4e27bdd9d4feef4a7a6323d86e6c9ef052164a56831a37b7c566/py_tes-1.1.2-py3-none-any.whl", hash = "sha256:9a4a3cd584ef47d41dde859e0404456225103ccbbe16fbb15d518e52c4994bc7", size = 12304, upload-time = "2025-04-09T03:31:16.702Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pycryptodome"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/a6/8452177684d5e906854776276ddd34eca30d1b1e15aa1ee9cefc289a33f5/pycryptodome-3.23.0.tar.gz", hash = "sha256:447700a657182d60338bab09fdb27518f8856aecd80ae4c6bdddb67ff5da44ef", size = 4921276, upload-time = "2025-05-17T17:21:45.242Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/5d/bdb09489b63cd34a976cc9e2a8d938114f7a53a74d3dd4f125ffa49dce82/pycryptodome-3.23.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0011f7f00cdb74879142011f95133274741778abba114ceca229adbf8e62c3e4", size = 2495152, upload-time = "2025-05-17T17:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ce/7840250ed4cc0039c433cd41715536f926d6e86ce84e904068eb3244b6a6/pycryptodome-3.23.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:90460fc9e088ce095f9ee8356722d4f10f86e5be06e2354230a9880b9c549aae", size = 1639348, upload-time = "2025-05-17T17:20:23.171Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/991da24c55c1f688d6a3b5a11940567353f74590734ee4a64294834ae472/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4764e64b269fc83b00f682c47443c2e6e85b18273712b98aa43bcb77f8570477", size = 2184033, upload-time = "2025-05-17T17:20:25.424Z" },
+    { url = "https://files.pythonhosted.org/packages/54/16/0e11882deddf00f68b68dd4e8e442ddc30641f31afeb2bc25588124ac8de/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb8f24adb74984aa0e5d07a2368ad95276cf38051fe2dc6605cbcf482e04f2a7", size = 2270142, upload-time = "2025-05-17T17:20:27.808Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fc/4347fea23a3f95ffb931f383ff28b3f7b1fe868739182cb76718c0da86a1/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d97618c9c6684a97ef7637ba43bdf6663a2e2e77efe0f863cce97a76af396446", size = 2309384, upload-time = "2025-05-17T17:20:30.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d9/c5261780b69ce66d8cfab25d2797bd6e82ba0241804694cd48be41add5eb/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9a53a4fe5cb075075d515797d6ce2f56772ea7e6a1e5e4b96cf78a14bac3d265", size = 2183237, upload-time = "2025-05-17T17:20:33.736Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/6f/3af2ffedd5cfa08c631f89452c6648c4d779e7772dfc388c77c920ca6bbf/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:763d1d74f56f031788e5d307029caef067febf890cd1f8bf61183ae142f1a77b", size = 2343898, upload-time = "2025-05-17T17:20:36.086Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/dc/9060d807039ee5de6e2f260f72f3d70ac213993a804f5e67e0a73a56dd2f/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:954af0e2bd7cea83ce72243b14e4fb518b18f0c1649b576d114973e2073b273d", size = 2269197, upload-time = "2025-05-17T17:20:38.414Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/34/e6c8ca177cb29dcc4967fef73f5de445912f93bd0343c9c33c8e5bf8cde8/pycryptodome-3.23.0-cp313-cp313t-win32.whl", hash = "sha256:257bb3572c63ad8ba40b89f6fc9d63a2a628e9f9708d31ee26560925ebe0210a", size = 1768600, upload-time = "2025-05-17T17:20:40.688Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/1d/89756b8d7ff623ad0160f4539da571d1f594d21ee6d68be130a6eccb39a4/pycryptodome-3.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6501790c5b62a29fcb227bd6b62012181d886a767ce9ed03b303d1f22eb5c625", size = 1799740, upload-time = "2025-05-17T17:20:42.413Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/61/35a64f0feaea9fd07f0d91209e7be91726eb48c0f1bfc6720647194071e4/pycryptodome-3.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9a77627a330ab23ca43b48b130e202582e91cc69619947840ea4d2d1be21eb39", size = 1703685, upload-time = "2025-05-17T17:20:44.388Z" },
+    { url = "https://files.pythonhosted.org/packages/db/6c/a1f71542c969912bb0e106f64f60a56cc1f0fabecf9396f45accbe63fa68/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:187058ab80b3281b1de11c2e6842a357a1f71b42cb1e15bce373f3d238135c27", size = 2495627, upload-time = "2025-05-17T17:20:47.139Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/4e/a066527e079fc5002390c8acdd3aca431e6ea0a50ffd7201551175b47323/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:cfb5cd445280c5b0a4e6187a7ce8de5a07b5f3f897f235caa11f1f435f182843", size = 1640362, upload-time = "2025-05-17T17:20:50.392Z" },
+    { url = "https://files.pythonhosted.org/packages/50/52/adaf4c8c100a8c49d2bd058e5b551f73dfd8cb89eb4911e25a0c469b6b4e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67bd81fcbe34f43ad9422ee8fd4843c8e7198dd88dd3d40e6de42ee65fbe1490", size = 2182625, upload-time = "2025-05-17T17:20:52.866Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e9/a09476d436d0ff1402ac3867d933c61805ec2326c6ea557aeeac3825604e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8987bd3307a39bc03df5c8e0e3d8be0c4c3518b7f044b0f4c15d1aa78f52575", size = 2268954, upload-time = "2025-05-17T17:20:55.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c5/ffe6474e0c551d54cab931918127c46d70cab8f114e0c2b5a3c071c2f484/pycryptodome-3.23.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa0698f65e5b570426fc31b8162ed4603b0c2841cbb9088e2b01641e3065915b", size = 2308534, upload-time = "2025-05-17T17:20:57.279Z" },
+    { url = "https://files.pythonhosted.org/packages/18/28/e199677fc15ecf43010f2463fde4c1a53015d1fe95fb03bca2890836603a/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:53ecbafc2b55353edcebd64bf5da94a2a2cdf5090a6915bcca6eca6cc452585a", size = 2181853, upload-time = "2025-05-17T17:20:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ea/4fdb09f2165ce1365c9eaefef36625583371ee514db58dc9b65d3a255c4c/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:156df9667ad9f2ad26255926524e1c136d6664b741547deb0a86a9acf5ea631f", size = 2342465, upload-time = "2025-05-17T17:21:03.83Z" },
+    { url = "https://files.pythonhosted.org/packages/22/82/6edc3fc42fe9284aead511394bac167693fb2b0e0395b28b8bedaa07ef04/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:dea827b4d55ee390dc89b2afe5927d4308a8b538ae91d9c6f7a5090f397af1aa", size = 2267414, upload-time = "2025-05-17T17:21:06.72Z" },
+    { url = "https://files.pythonhosted.org/packages/59/fe/aae679b64363eb78326c7fdc9d06ec3de18bac68be4b612fc1fe8902693c/pycryptodome-3.23.0-cp37-abi3-win32.whl", hash = "sha256:507dbead45474b62b2bbe318eb1c4c8ee641077532067fec9c1aa82c31f84886", size = 1768484, upload-time = "2025-05-17T17:21:08.535Z" },
+    { url = "https://files.pythonhosted.org/packages/54/2f/e97a1b8294db0daaa87012c24a7bb714147c7ade7656973fd6c736b484ff/pycryptodome-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:c75b52aacc6c0c260f204cbdd834f76edc9fb0d8e0da9fbf8352ef58202564e2", size = 1799636, upload-time = "2025-05-17T17:21:10.393Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3d/f9441a0d798bf2b1e645adc3265e55706aead1255ccdad3856dbdcffec14/pycryptodome-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:11eeeb6917903876f134b56ba11abe95c0b0fd5e3330def218083c7d98bbcb3c", size = 1703675, upload-time = "2025-05-17T17:21:13.146Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR added functions to get and parse the results from Minio of the Submission layer, based on the children's submission ID and their statuses.

So the user can use the command `wb.fetch_all_results()` (get results from all TREs in the config) or `wb.fetch_result_by_tre(tre="DEMO")` to get the results. If no `task_id` is passed, the last task ID will be used. The `tre` param is required for the command `fetch_result_by_tre`

Before fetching the results, if the status is failed or not completed, the app will return with a message.

Closes https://github.com/federated-research/technical-planning/issues/469