### PR TITLE
Merge minio commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dev = [
 reportMissingTypeStubs = false
 
 [tool.ruff]
-line-length = 88
+line-length = 100
 target-version = "py311"
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "five-safes-tes-workbench"
-version = "0.2.2"
+version = "0.2.3"
 description = "Common feature library for working with 5S-TES"
 readme = "README.md"
 authors = [

--- a/src/five_safes_tes_workbench/core/minio/minio_client.py
+++ b/src/five_safes_tes_workbench/core/minio/minio_client.py
@@ -64,7 +64,6 @@ class MinioClientBuilder:
         self,
         task_id: str,
         output_dir: Path,
-        bucket: str | None = None,
     ) -> list[Path]:
         """
         Download all output objects for a task to a local directory.
@@ -84,14 +83,12 @@ class MinioClientBuilder:
         List of :class:`~pathlib.Path` objects pointing to every downloaded
         file.
         """
-        object_paths = list_results(self._client, self._config, task_id, bucket=bucket)
+        object_paths = list_results(self._client, self._config, task_id)
 
         downloaded: list[Path] = []
         for path in object_paths:
             logger.info("Downloading result object: %s", path)
-            local_path = download_result(
-                self._client, self._config, path, output_dir, bucket=bucket
-            )
+            local_path = download_result(self._client, self._config, path, output_dir)
             downloaded.append(local_path)
 
         return downloaded

--- a/src/five_safes_tes_workbench/helpers/children_task.py
+++ b/src/five_safes_tes_workbench/helpers/children_task.py
@@ -75,14 +75,16 @@ def is_child_task_completed(child_task_info: ChildTaskInfo) -> bool:
         or child_task_info.status == TaskStatus.FAILURE
     ):
         logger.warning(
-            "Child task %s is failed, cancelled or data out approval rejected. Please try again later.",
+            "Child task %s is failed, cancelled or data out approval rejected."
+            "Please try again later.",
             child_task_info.id,
         )
         return False
 
     elif child_task_info.status != TaskStatus.COMPLETED:
         logger.warning(
-            "Child task %s is not completed or failed, so results are not available yet. Current status: %s",
+            "Child task %s is not completed or failed, so results are not available yet."
+            "Current status: %s",
             child_task_info.id,
             TASK_STATUS_DESCRIPTIONS[TaskStatus(child_task_info.status)],
         )

--- a/src/five_safes_tes_workbench/helpers/children_task.py
+++ b/src/five_safes_tes_workbench/helpers/children_task.py
@@ -46,8 +46,9 @@ def get_child_task_info(
             f"No child task info found for parent task {parent_task_id} and TRE {tre}"
         )
     logger.info(
-        "Child task info: %s, status: %s",
+        "Child task info: %s, TRE: %s, status: %s",
         child_task_info["id"],
+        tre,
         TASK_STATUS_DESCRIPTIONS[TaskStatus(child_task_info["status"])],
     )
     return ChildTaskInfo(

--- a/src/five_safes_tes_workbench/helpers/minio.py
+++ b/src/five_safes_tes_workbench/helpers/minio.py
@@ -38,7 +38,6 @@ def list_results(
     client: Minio,
     config: ConfigValidationModel,
     task_id: str,
-    bucket: str | None = None,
 ) -> list[str]:
     """
     List all output objects written by a task.
@@ -49,8 +48,6 @@ def list_results(
     Parameters
     ----------
     - task_id: ID returned by the TES submission.
-    - bucket: Override the bucket from config. Defaults to
-        ``config.minio_output_bucket``.
     - client: MinIO client (should be already initialised before calling this function).
     - config: ConfigValidationModel (should be already validated before calling this function).
 
@@ -59,12 +56,12 @@ def list_results(
     List of object names found under the task prefix.
     """
 
-    resolved_bucket = bucket or config.minio_output_bucket
+    resolved_bucket = config.minio_output_bucket
     prefix = f"{task_id}/"
 
     try:
         objects = client.list_objects(resolved_bucket, prefix=prefix, recursive=True)
-        names = [obj.object_name for obj in objects]
+        names = [obj.object_name for obj in objects if obj.object_name is not None]
         if not names:
             logger.warning("No result objects found for task %s", task_id)
             return []
@@ -80,7 +77,6 @@ def download_result(
     config: ConfigValidationModel,
     object_path: str,
     output_dir: Path,
-    bucket: str | None = None,
 ) -> Path:
     """
     Download a single result object from MinIO to a local file.
@@ -95,13 +91,12 @@ def download_result(
     - object_path: Full object path within the bucket (e.g.
         ``"<task_id>/output.csv"``).
     - output_dir: Local directory to write the file into.
-    - bucket: Override the bucket from config.
 
     Returns
     -------
     The :class:`~pathlib.Path` of the downloaded local file.
     """
-    resolved_bucket = bucket or config.minio_output_bucket
+    resolved_bucket = config.minio_output_bucket
 
     # Strip the leading <task_id>/ prefix so the filename is clean.
     parts = object_path.split("/", 1)

--- a/src/five_safes_tes_workbench/notebooks/workbench-example.ipynb
+++ b/src/five_safes_tes_workbench/notebooks/workbench-example.ipynb
@@ -17,13 +17,14 @@
         "    minio_sts_endpoint=\"http://localhost:9000/sts\",\n",
         "    minio_endpoint=\"http://localhost:9000\",\n",
         "    minio_output_bucket=\"11343output\",\n",
-        "    tres=[\"DEMO\", \"DEMO2\"],\n",
+        "    tres=[\"DEMO\"],\n",
         "    client_id=\"Dare-Control-API\",\n",
         "    client_secret=\"2e60b956-16bc-4dea-8b49-118a8baac5e5\",\n",
         "    username=\"globaladminuser\",\n",
         "    password=\"password123\",\n",
         "    keycloak_url=\"http://localhost:8085/\",\n",
-        ")"
+        ")\n",
+        "\n"
       ]
     },
     {
@@ -129,10 +130,41 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "wb.fetch_all_results(task_id=\"task_id\")\n",
-        "wb.fetch_all_results()\n",
-        "wb.fetch_results_by_tre(tre=\"task_id\")\n",
-        "wb.fetch_results_by_tre(task_id=\"tre_id\", tre=\"task_id\")"
+        "wb.fetch_outputs()\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "8591125b",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "wb.fetch_outputs(tre=\"DEMO\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "59dc84cd",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "wb.fetch_outputs(task_id=155)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "a494c58e",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "wb.fetch_outputs(tre=\"DEMO\", task_id=1)"
       ]
     }
   ],

--- a/src/five_safes_tes_workbench/notebooks/workbench-example.ipynb
+++ b/src/five_safes_tes_workbench/notebooks/workbench-example.ipynb
@@ -23,8 +23,7 @@
         "    username=\"globaladminuser\",\n",
         "    password=\"password123\",\n",
         "    keycloak_url=\"http://localhost:8085/\",\n",
-        ")\n",
-        "\n"
+        ")\n"
       ]
     },
     {
@@ -124,14 +123,21 @@
       ]
     },
     {
+      "cell_type": "markdown",
+      "id": "22bc196b",
+      "metadata": {},
+      "source": [
+        "Minio Commands"
+      ]
+    },
+    {
       "cell_type": "code",
       "execution_count": null,
       "id": "b6b00d88",
       "metadata": {},
       "outputs": [],
       "source": [
-        "wb.fetch_outputs()\n",
-        "\n"
+        "wb.fetch_outputs()\n"
       ]
     },
     {
@@ -153,7 +159,7 @@
       "outputs": [],
       "source": [
         "\n",
-        "wb.fetch_outputs(task_id=155)\n"
+        "wb.fetch_outputs(task_id=1)\n"
       ]
     },
     {
@@ -164,7 +170,7 @@
       "outputs": [],
       "source": [
         "\n",
-        "wb.fetch_outputs(tre=\"DEMO\", task_id=1)"
+        "wb.fetch_outputs(task_id=1, tre=\"DEMO\")"
       ]
     }
   ],

--- a/src/five_safes_tes_workbench/workbench.py
+++ b/src/five_safes_tes_workbench/workbench.py
@@ -100,84 +100,20 @@ class Workbench:
         self._last_task_id = task_id
         return task_id
 
-    # ----- MinIO Results Commands -----
+    # ----- MinIO Results Command -----
 
-    def fetch_results_by_tre(
+    def fetch_outputs(
         self,
-        task_id: str | None = None,
         tre: str | None = None,
-        bucket: str | None = None,
-        output_dir: Path | str | None = None,
-    ) -> list[Path]:
-        """
-        Download all output objects for a completed TES task from MinIO to disk.
-
-        Files are saved under ``<output_dir>/<filename>`` where
-        ``output_dir`` defaults to an ``output/`` folder created next to
-        the calling notebook (i.e. ``Path.cwd() / "output"``).
-
-        Authentication is re-used from the earlier :meth:`validate` call.
-        Credentials are exchanged at the configured STS endpoint so that a
-        temporary MinIO session is obtained automatically.
-
-        Parameters
-        ----------
-        - task_id: ID of the task whose results to retrieve. Defaults to
-          the ID returned by the most recent :meth:`submit` call.
-        - tre: Name of the TRE to download the results for.
-        - bucket: Override the output bucket from config. Defaults to
-          ``config.minio_output_bucket``.
-        - output_dir: Directory to write downloaded files into. Defaults
-          to ``Path.cwd() / "output" / <tre>``.
-
-        Returns
-        -------
-        List of :class:`~pathlib.Path` objects for every downloaded file.
-        """
-        resolved_id = task_id or self._last_task_id
-        if resolved_id is None:
-            raise ValueError(
-                "No Submission task ID available. Either call submit() first or pass "
-                "a task_id explicitly to fetch_result_by_tre()."
-            )
-
-        if tre is None:
-            raise ValueError(
-                "No TRE available. Please specify the TRE to fetch the results for."
-            )
-        if tre not in self._validator.config.tres:
-            raise ValueError(
-                f"TRE {tre} not found in the configuration. Please specify a valid TRE."
-            )
-        child_task_info = get_child_task_info(self._validator.config, resolved_id, tre)
-
-        if not is_child_task_completed(child_task_info):
-            return []
-
-        resolved_output_dir = (
-            Path(output_dir)
-            if output_dir is not None
-            else Path.cwd() / "output" / tre / str(child_task_info.id)
-        )
-
-        minio_client = MinioClientBuilder(
-            config=self._validator.config,
-            auth=self._validator.auth,
-        )
-
-        return minio_client.download_results(
-            child_task_info.id, resolved_output_dir, bucket=bucket
-        )
-
-    def fetch_all_results(
-        self,
-        task_id: str | None = None,
-        bucket: str | None = None,
+        task_id: int | None = None,
         output_dir: Path | str | None = None,
     ) -> dict[str, list[Path]]:
         """
         Download all output objects for a completed TES task from MinIO to disk
         for every configured TRE.
+
+        If a TRE is specified, only the output objects for that TRE are downloaded.
+        If no TRE is specified, all output objects for all TREs are downloaded.
 
         Files are saved under ``<output_dir>/<tre>/<filename>`` where
         ``output_dir`` defaults to an ``output/`` folder created next to
@@ -189,20 +125,20 @@ class Workbench:
 
         Parameters
         ----------
+        - tre: Name of the TRE whose results to retrieve. If not specified, all TREs are retrieved.
         - task_id: ID of the task whose results to retrieve. Defaults to
           the ID returned by the most recent :meth:`submit` call.
-        - bucket: Override the output bucket from config. Defaults to
-          ``config.minio_output_bucket``.
         - output_dir: Root directory for downloads. Each TRE gets its own
           sub-folder ``<output_dir>/<tre>/``. Defaults to
-          ``Path.cwd() / "output"``.
+          ``Path.cwd() / "output" / <tre> / <task_id>``.
 
         Returns
         -------
         Dict mapping each TRE name to the list of
         :class:`~pathlib.Path` objects for its downloaded files.
         """
-        resolved_id = task_id or self._last_task_id
+        resolved_id = str(task_id) if task_id is not None else self._last_task_id
+        print("resolved_id", resolved_id)
         if resolved_id is None:
             raise ValueError(
                 "No Submission task ID available. Either call submit() first or pass "
@@ -215,12 +151,18 @@ class Workbench:
             config=self._validator.config,
             auth=self._validator.auth,
         )
-        for tre in self._validator.config.tres:
+
+        if tre is not None:
+            if tre not in self._validator.config.tres:
+                raise ValueError(
+                    f"TRE {tre} not found in the configuration. Please specify a valid TRE."
+                )
             child_task_info = get_child_task_info(
                 self._validator.config, resolved_id, tre
             )
+
             if not is_child_task_completed(child_task_info):
-                continue
+                results[tre] = []
 
             resolved_output_dir = (
                 Path(output_dir)
@@ -228,7 +170,24 @@ class Workbench:
                 else Path.cwd() / "output" / tre / str(child_task_info.id)
             )
             results[tre] = minio_client.download_results(
-                child_task_info.id, resolved_output_dir, bucket=bucket
+                child_task_info.id, resolved_output_dir
             )
+            return results
+        else:
+            for tre_in_config in self._validator.config.tres:
+                child_task_info = get_child_task_info(
+                    self._validator.config, resolved_id, tre_in_config
+                )
+                if not is_child_task_completed(child_task_info):
+                    continue
+
+                resolved_output_dir = (
+                    Path(output_dir)
+                    if output_dir is not None
+                    else Path.cwd() / "output" / tre_in_config / str(child_task_info.id)
+                )
+                results[tre_in_config] = minio_client.download_results(
+                    child_task_info.id, resolved_output_dir
+                )
 
         return results

--- a/src/five_safes_tes_workbench/workbench.py
+++ b/src/five_safes_tes_workbench/workbench.py
@@ -138,7 +138,7 @@ class Workbench:
         :class:`~pathlib.Path` objects for its downloaded files.
         """
         resolved_id = str(task_id) if task_id is not None else self._last_task_id
-        print("resolved_id", resolved_id)
+
         if resolved_id is None:
             raise ValueError(
                 "No Submission task ID available. Either call submit() first or pass "

--- a/uv.lock
+++ b/uv.lock
@@ -217,7 +217,7 @@ wheels = [
 
 [[package]]
 name = "five-safes-tes-workbench"
-version = "0.1.1"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "minio" },


### PR DESCRIPTION
This PR simplified Minio commands in WB:
- Only one command to fetch the outputs from Minio
- Accept three params: `tre` (the target TRE to fetch), `task_id` (the target task ID to fetch) and `output_dir` (custom output DIR)
    - If no `tre` provided: try to fetch the output from all of the TREs in the configs
    - If no `task_id` provided: try to use the ID of the last submitted task
    - If no `output_dir` provided: use the default as the path next to the Notebook
 - No overwriting `bucket`
 - More details on Child task Info