### PR TITLE
Fix indentation and formatting in example-config.yml

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -15,17 +15,17 @@ config:
     - "Add more TREs as needed"
 
 
-  auth:
-    # ---- Option 1: Access Token ----
-    # (Use Access Token if you have one from the Submission UI.)
+auth:
+  # ---- Option 1: Access Token ----
+  # (Use Access Token if you have one from the Submission UI.)
 
-    access_token: "your-access-token-here"
+  access_token: "your-access-token-here"
 
-    # ---- Option 2: Keycloak Credentials ----
-    # (Use Keycloak credentials if you want the Workbench to obtain an access token on your behalf.)
+  # ---- Option 2: Keycloak Credentials ----
+  # (Use Keycloak credentials if you want the Workbench to obtain an access token on your behalf.)
 
-    client_id: "your-keycloak-client-id"
-    client_secret: "your-keycloak-client-secret"
-    username: "your-keycloak-username"
-    password: "your-keycloak-password"
-    keycloak_url: "http://localhost:your-keycloak-port/"
+  client_id: "your-keycloak-client-id"
+  client_secret: "your-keycloak-client-secret"
+  username: "your-keycloak-username"
+  password: "your-keycloak-password"
+  keycloak_url: "http://localhost:your-keycloak-port/"


### PR DESCRIPTION
minor bugfix in example config.

If a user used it as it was, and copied and pasted correct data in, it would fail to validate due to an indentation error.