### PR TITLE
SQL Template to perform Analysis

### DIFF
--- a/src/five_safes_tes_workbench/common/params/simple_sql_params.py
+++ b/src/five_safes_tes_workbench/common/params/simple_sql_params.py
@@ -21,3 +21,5 @@ class SimpleSQLUserParams(TypedDict):
     description: NotRequired[str]
     output_url: NotRequired[str]
     output_path: NotRequired[str]
+    output_format: NotRequired[str]
+    analysis: NotRequired[str]

--- a/src/five_safes_tes_workbench/core/tes/templates/simple_sql.py
+++ b/src/five_safes_tes_workbench/core/tes/templates/simple_sql.py
@@ -30,16 +30,30 @@ class SimpleSQLTemplate(BaseTESTemplate[SimpleSQLUserParams]):
         The user's SQL query is injected into the command list.
         """
 
+        # ---- Available Docker images for this template ----
+
+        _DEFAULT_IMAGE = "harbor.federated-analytics.ac.uk/5s-tes-analysis-tools/5s-tes-analysis-tools-tre-sqlpg:1.0.0"  # noqa: E501
+        _UON_ANALYSIS_IMAGE = "ghcr.io/health-informatics-uon/five-safes-tes-analytics-dev:sha-dbf029b" # noqa: E501
+
         # ---- Fixed parameters for this template ----
 
-        _IMAGE = "harbor.federated-analytics.ac.uk/5s-tes-analysis-tools/5s-tes-analysis-tools-tre-sqlpg:1.0.0"  # noqa: E501
         _DESCRIPTION = overrides.get("description", "Simple SQL Task")
         _OUTPUT_PATH = overrides.get("output_path", "/outputs")
         _OUTPUT_URL = overrides.get("output_url", "s3://")
+        _OUTPUT_FORMAT = overrides.get("output_format")
+        _ANALYSIS = overrides.get("analysis")
         _COMMAND = [
             f"--Output={_OUTPUT_PATH}/output.csv",
             f"--Query={overrides['query']}",
         ]
+
+        if _OUTPUT_FORMAT:
+            _COMMAND.append(f"--output-format={_OUTPUT_FORMAT}")
+        if _ANALYSIS:
+            _COMMAND.append(f"--analysis={_ANALYSIS}")
+
+
+        _IMAGE = _DEFAULT_IMAGE if not _ANALYSIS else _UON_ANALYSIS_IMAGE
 
         return TESTaskParams(
             name=overrides["name"],


### PR DESCRIPTION
✨Feature

#### PR Description

This PR makes the `SimpleSQLTemplate` compatible with analysis-capable execution by adding optional support for `analysis` and `output_format` parameters.

Previously, the SQL template only supported the default SQL execution image and required only `name` and `query`. With this change, callers can optionally request analysis behaviour without breaking existing usage.

## Changes

- Added optional `analysis` to `SimpleSQLUserParams`.
- Added optional `output_format` to `SimpleSQLUserParams`
- Updated `SimpleSQLTemplate.resolve()` to append:
  - `--analysis=<value>` when `analysis` is provided
  - `--output-format=<value>` when `output_format` is provided
- Added image selection logic:
  - use the default SQL image when no analysis is requested
  - use the analysis-capable image when `analysis` is provided