### PR TITLE
New Template for Analysis

### DIFF
--- a/src/five_safes_tes_workbench/common/params/analysis_params.py
+++ b/src/five_safes_tes_workbench/common/params/analysis_params.py
@@ -1,0 +1,28 @@
+from typing import NotRequired, Required, TypedDict
+
+
+class AnalysisUserParams(TypedDict):
+    """
+    User-facing parameters for the analysis template.
+
+    Required:
+        - name: Task name.
+        - query: SQL query to execute.
+        - analysis_type: Analysis mode to run.
+
+    Optional (Solved internally):
+        - description: TES task description.
+        - output_url: Output storage URL.
+        - output_path: Output directory path.
+        - output_filename: Output file path written by the container.
+        - output_format: Output serialization format.
+    """
+
+    name: Required[str]
+    query: Required[str]
+    analysis_type: Required[str]
+    description: NotRequired[str]
+    output_url: NotRequired[str]
+    output_path: NotRequired[str]
+    output_filename: NotRequired[str]
+    output_format: NotRequired[str]

--- a/src/five_safes_tes_workbench/core/tes/registry.py
+++ b/src/five_safes_tes_workbench/core/tes/registry.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from ..base.tes_template_abc import BaseTESTemplate
 from .base_registry import BaseTemplateRegistry
+from .templates.analysis import AnalysisTemplate
 from .templates.bunny import BunnyTemplate
 from .templates.custom import CustomTemplate
 from .templates.hello_world import HelloWorldTemplate
@@ -26,6 +27,7 @@ _DEFAULT_TEMPLATES: list[type[BaseTESTemplate[Any]]] = [
     CustomTemplate,
     SimpleSQLTemplate,
     BunnyTemplate,
+    AnalysisTemplate,
     # --- Add new templates above ---
 ]
 

--- a/src/five_safes_tes_workbench/core/tes/templates/analysis.py
+++ b/src/five_safes_tes_workbench/core/tes/templates/analysis.py
@@ -1,0 +1,70 @@
+from ....common.params.analysis_params import AnalysisUserParams
+from ....common.params.tes_builder_params import (
+    ExecutorTESParams,
+    OutputTESParams,
+    TESTaskParams,
+)
+from ...base.tes_template_abc import BaseTESTemplate
+
+
+class AnalysisTemplate(BaseTESTemplate[AnalysisUserParams]):
+    """
+    Analysis template for TES tasks.
+
+    Executes the analytics container with a user query and analysis mode.
+
+    Method Usage:
+    - `build_tes.analysis(name=..., query=..., analysis_type=...)`
+    """
+
+    @property
+    def name(self) -> str:
+        """
+        Unique name for this template.
+        """
+        return "analysis"
+
+    def resolve(self, overrides: AnalysisUserParams) -> TESTaskParams:
+        """
+        Merges user-provided params with internal defaults.
+        """
+
+        # ---- Fixed parameters for this template ----
+
+        _IMAGE = "ghcr.io/health-informatics-uon/five-safes-tes-analytics-dev:sha-dbf029b"
+        _DESCRIPTION = overrides.get("description", "Analysis Task")
+        _OUTPUT_PATH = overrides.get("output_path", "/outputs")
+        _OUTPUT_URL = overrides.get("output_url", "s3://")
+        _OUTPUT_FILENAME = overrides.get(
+            "output_filename", f"{_OUTPUT_PATH}/output"
+        )
+        _OUTPUT_FORMAT = overrides.get("output_format", "json")
+        _WORKDIR = "/app"
+
+        _COMMAND = [
+            f"--user-query={overrides['query']}",
+            f"--analysis={overrides['analysis_type']}",
+            f"--output-filename={_OUTPUT_FILENAME}",
+            f"--output-format={_OUTPUT_FORMAT}",
+        ]
+
+        return TESTaskParams(
+            name=overrides["name"],
+            executors=[
+                ExecutorTESParams(
+                    image=_IMAGE,
+                    command=_COMMAND,
+                    workdir=_WORKDIR,
+                    env={},
+                )
+            ],
+            outputs=[
+                OutputTESParams(
+                    name=overrides["name"],
+                    description=_DESCRIPTION,
+                    url=_OUTPUT_URL,
+                    path=_OUTPUT_PATH,
+                )
+            ],
+            volumes=[],
+        )

--- a/src/five_safes_tes_workbench/notebooks/workbench-example.ipynb
+++ b/src/five_safes_tes_workbench/notebooks/workbench-example.ipynb
@@ -123,6 +123,26 @@
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "efbc16a3",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# ----- Analysis Template -----\n",
+        "\n",
+        "_query = \"SELECT value_as_number FROM \\\"NottinghamDemo\\\".measurement \\nWHERE measurement_concept_id = 43055141\\nAND value_as_number IS NOT NULL\"\n",
+        "\n",
+        "wb.build_tes.analysis(\n",
+        "    name=\"Analysis Template testing from Workbench\",\n",
+        "    query=_query,\n",
+        "    analysis_type=\"mean\",\n",
+        ")\n",
+        "\n",
+        "wb.submit()"
+      ]
+    },
+    {
       "cell_type": "markdown",
       "id": "22bc196b",
       "metadata": {},
@@ -176,7 +196,7 @@
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": ".venv",
+      "display_name": "five-safes-tes-workbench",
       "language": "python",
       "name": "python3"
     },
@@ -190,7 +210,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.13.7"
+      "version": "3.13.11"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
✨ Feature - #44

#### Summary

Introduce a new built-in `analysis` template to the workbench so users can build TES payloads for the analytics container without manually constructing executor arguments.

This template supports the analytics image and analysis type to run, and exposes the user-facing parameters needed to build the TES message cleanly.

#### Changes

- Add a new template named `analysis`
- Register the template in the default TES template registry in `registry.py`
- Add a typed user params contract in `analysis_params.py`
- Implement the template in `analysis.py`
- Configure the template to build an executor using image:
  `ghcr.io/health-informatics-uon/five-safes-tes-analytics-dev:sha-dbf029b`

## Required Params

- `name`
- `query`
- `analysis_type`

Closes #44